### PR TITLE
fixed compilation error with tango+ldc1 64bit

### DIFF
--- a/wrap/APILookupGLib.txt
+++ b/wrap/APILookupGLib.txt
@@ -63,7 +63,7 @@ version(Tango)
 {
 	//avoid some conflicts with other string aliases.
 	static if( !is(string) )
-		private alias char[] string;
+		alias char[] string;
 }
 
 version( Windows )


### PR DESCRIPTION
the string alias shouldnt be private if it is meant to be used outside that file
