### PR TITLE
Color.getValue had wrong bitshifts

### DIFF
--- a/wrap/APILookupGdk.txt
+++ b/wrap/APILookupGdk.txt
@@ -794,7 +794,7 @@ code: start
 	/** */
 	ulong getValue()
 	{
-		return (cast(ulong)gdkColor.red <<32) | (cast(ulong)gdkColor.green << 16) | (cast(ulong)gdkColor.blue);
+		return (cast(ulong)gdkColor.red <<16) | (cast(ulong)gdkColor.green << 8) | (cast(ulong)gdkColor.blue);
 	}
 	
 	/** */


### PR DESCRIPTION
Bitshifting red 32 bits results in either overflow or zero. In any case, ldc1 refused to compile it. Fixed it here.
