### PR TITLE
Fix the compile error using dmd2 32bit in windows.

### DIFF
--- a/src/gtkc/glibtypes.d
+++ b/src/gtkc/glibtypes.d
@@ -109,7 +109,7 @@ version (Windows)
 		//Phobos defines this function in std.c.stdio
 		extern (C) FILE*  fdopen(int, char*);
 	}
-	version(D_Version2) version(Win64)
+	version(D_Version2)
 	{
 		private import core.stdc.stdio;
 		


### PR DESCRIPTION
The version(64) in glibtypes.d will make fdopen is undefined in windows/dmd2/32bit.
