### PR TITLE
Add DUB building support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
         "gtk-d:gtkd": "~master",
         "gtk-d:gtkdgl": "~master",
         "gtk-d:sv": "~master",
-        "gtk-d:gstreamer": "~master"
+        "gtk-d:gstreamer": "~master",
+        "gtk-d:vte": "~master"
     },
 
     "subPackages" : [
@@ -42,6 +43,12 @@
             "name": "gstreamer",
             "outputName": ["gstreamerd"],
             "sourcePaths": ["srcgstreamer"],
+            "libs-posix": ["dl"]
+        },
+        {
+            "name": "vte",
+            "outputName": ["libvted"],
+            "sourcePaths": ["srcvte"],
             "libs-posix": ["dl"]
         }
     ]


### PR DESCRIPTION
It would be greate if GtkD will be available through DUB (http://code.dlang.org/about). I've made packet.json to build GtkD with dub.

Packet name was transformed to match dub packet name conventions. Separation into sublibs is preserved to not link with needless ones.

If this pull request merged, someone should add packet to dub registry.

Tested on Fedora 18 x86_64,  Windows 7 x86 with latest dmd 2.063.2 and dub 0.9.18. Although there is old linker bug preventing linking in debug mode under Win32.
