### PR TITLE
Give subpackages the correct version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,11 +15,12 @@
         "Mike Wey",
         "hauptmech"
     ],
-		"gtk-d:gtkdgl": "~>2.4.0",
-		"gtk-d:sv": "~>2.4.0",
-		"gtk-d:vte": "~>2.4.0",
-		"gtk-d:gtkd": "~>2.4.0",
-		"gtk-d:gstreamer": "~>2.4.0"
+    "dependencies": {
+        "gtk-d:gtkdgl": "~>2.4.0",
+        "gtk-d:sv": "~>2.4.0",
+        "gtk-d:vte": "~>2.4.0",
+        "gtk-d:gtkd": "~>2.4.0",
+        "gtk-d:gstreamer": "~>2.4.0"
     },
 
     "subPackages" : [


### PR DESCRIPTION
Prevents a `==2.4.0` build from requiring `~master`
