### PR TITLE
Win32mscoff needs fdopen defined, like Win64

### DIFF
--- a/src/gtkc/glibtypes.d
+++ b/src/gtkc/glibtypes.d
@@ -97,7 +97,7 @@ version (Windows)
 		//Phobos defines this function in std.c.stdio
 		extern (C) FILE*  fdopen(int, char*);
 	}
-	version(D_Version2) version(Win64)
+	version(D_Version2) version(CRuntime_Microsoft)
 	{
 		private import core.stdc.stdio;
 		


### PR DESCRIPTION
This fixes compilation on windows with DMD in -m32mscoff mode

There are some additional difficulties with an ICE in debug mode with dmd at the moment, but this is thus far the only thing I've needed to fix on GtkD's side.