### PR TITLE
GtkD Event Handling

### DIFF
--- a/wrap/APILookupGObject.txt
+++ b/wrap/APILookupGObject.txt
@@ -315,9 +315,9 @@ code: start
 	protected class OnNotifyDelegateWrapper
 	{
 		void delegate(ParamSpec, ObjectG) dlg;
-		ulong handlerId;
+		gulong handlerId;
 		ConnectFlags flags;
-		this(void delegate(ParamSpec, ObjectG) dlg, ulong handlerId, ConnectFlags flags)
+		this(void delegate(ParamSpec, ObjectG) dlg, gulong handlerId, ConnectFlags flags)
 		{
 			this.dlg = dlg;
 			this.handlerId = handlerId;

--- a/wrap/APILookupGObject.txt
+++ b/wrap/APILookupGObject.txt
@@ -334,20 +334,16 @@ code: start
 	 * is called to reinstate the previous value.
 	 *
 	 * This signal is typically used to obtain change notification for a
-	 * single property, by specifying the property name as a detail in the
-	 * g_signal_connect() call, like this:
-	 * |[<!-- language="C" -->
-	 * g_signal_connect (text_view->buffer, "notify::paste-target-list",
-	 * G_CALLBACK (gtk_text_view_target_list_notify),
-	 * text_view)
-	 * ]|
+	 * single property.
+	 *
 	 * It is important to note that you must use
-	 * [canonical][canonical-parameter-name] parameter names as
-	 * detail strings for the notify signal.
+	 * canonical parameter names for the property.
 	 *
 	 * Params:
-	 *     pspec = the #GParamSpec of the property which changed.
-	 */
+	 *     dlg          = The callback.
+	 *     property     = Set this if you only want to receive the signal for a specific property.
+	 *     connectFlags = The behavior of the signal's connection.
+	 */	
 	gulong addOnNotify(void delegate(ParamSpec, ObjectG) dlg, string property = "", ConnectFlags connectFlags=cast(ConnectFlags)0)
 	{
 		string signalName;

--- a/wrap/APILookupGObject.txt
+++ b/wrap/APILookupGObject.txt
@@ -311,9 +311,21 @@ code: start
 		return obj.doref();
 	}
 
-	int[string] connectedSignals;
 
-	void delegate(ParamSpec, ObjectG)[] onNotifyListeners;
+	protected class OnNotifyDelegateWrapper
+	{
+		void delegate(ParamSpec, ObjectG) dlg;
+		ulong handlerId;
+		ConnectFlags flags;
+		this(void delegate(ParamSpec, ObjectG) dlg, ulong handlerId, ConnectFlags flags)
+		{
+			this.dlg = dlg;
+			this.handlerId = handlerId;
+			this.flags = flags;
+		}
+	}
+	protected OnNotifyDelegateWrapper[] onNotifyListeners;
+
 	/**
 	 * The notify signal is emitted on an object when one of its
 	 * properties has been changed. Note that getting this signal
@@ -322,17 +334,21 @@ code: start
 	 * is called to reinstate the previous value.
 	 *
 	 * This signal is typically used to obtain change notification for a
-	 * single property.
-	 *
+	 * single property, by specifying the property name as a detail in the
+	 * g_signal_connect() call, like this:
+	 * |[<!-- language="C" -->
+	 * g_signal_connect (text_view->buffer, "notify::paste-target-list",
+	 * G_CALLBACK (gtk_text_view_target_list_notify),
+	 * text_view)
+	 * ]|
 	 * It is important to note that you must use
-	 * canonical parameter names for the property.
+	 * [canonical][canonical-parameter-name] parameter names as
+	 * detail strings for the notify signal.
 	 *
 	 * Params:
-	 *     dlg          = The callback.
-	 *     property     = Set this if you only want to receive the signal for a specific property.
-	 *     connectFlags = The behavior of the signal's connection.
+	 *     pspec = the #GParamSpec of the property which changed.
 	 */
-	void addOnNotify(void delegate(ParamSpec, ObjectG) dlg, string property = "", ConnectFlags connectFlags=cast(ConnectFlags)0)
+	gulong addOnNotify(void delegate(ParamSpec, ObjectG) dlg, string property = "", ConnectFlags connectFlags=cast(ConnectFlags)0)
 	{
 		string signalName;
 
@@ -341,24 +357,37 @@ code: start
 		else
 			signalName = "notify::"~ property;
 
-		if ( !(signalName in connectedSignals) )
-		{
-			Signals.connectData(
+		onNotifyListeners ~= new OnNotifyDelegateWrapper(dlg, 0, connectFlags);
+		onNotifyListeners[onNotifyListeners.length - 1].handlerId = Signals.connectData(
 			this,
 			signalName,
 			cast(GCallback)&callBackNotify,
-			cast(void*)this,
-			null,
+			cast(void*)onNotifyListeners[onNotifyListeners.length - 1],
+			cast(GClosureNotify)&callBackNotifyDestroy,
 			connectFlags);
-			connectedSignals[signalName] = 1;
-		}
-		onNotifyListeners ~= dlg;
+		return onNotifyListeners[onNotifyListeners.length - 1].handlerId;
 	}
-	extern(C) static void callBackNotify(GObject* gobjectStruct, GParamSpec* pspec, ObjectG _objectG)
+	
+	extern(C) static void callBackNotify(GObject* objectgStruct, GParamSpec* pspec,OnNotifyDelegateWrapper wrapper)
 	{
-		foreach ( void delegate(ParamSpec, ObjectG) dlg ; _objectG.onNotifyListeners )
+		wrapper.dlg(ObjectG.getDObject!(ParamSpec)(pspec), wrapper.outer);
+	}
+	
+	extern(C) static void callBackNotifyDestroy(OnNotifyDelegateWrapper wrapper, GClosure* closure)
+	{
+		wrapper.outer.internalRemoveOnNotify(wrapper);
+	}
+
+	protected void internalRemoveOnNotify(OnNotifyDelegateWrapper source)
+	{
+		foreach(index, wrapper; onNotifyListeners)
 		{
-			dlg(ObjectG.getDObject!(ParamSpec)(pspec), _objectG);
+			if (wrapper.dlg == source.dlg && wrapper.flags == source.flags && wrapper.handlerId == source.handlerId)
+			{
+				onNotifyListeners[index] = null;
+				onNotifyListeners = std.algorithm.remove(onNotifyListeners, index);
+				break;
+			}
 		}
 	}
 code: end

--- a/wrap/APILookupGio.txt
+++ b/wrap/APILookupGio.txt
@@ -48,9 +48,9 @@ code: start
 	protected class ScopedOnCommandLineDelegateWrapper
 	{
 		int delegate(Scoped!ApplicationCommandLine, Application) dlg;
-		ulong handlerId;
+		gulong handlerId;
 		ConnectFlags flags;
-		this(int delegate(Scoped!ApplicationCommandLine, Application) dlg, ulong handlerId, ConnectFlags flags)
+		this(int delegate(Scoped!ApplicationCommandLine, Application) dlg, gulong handlerId, ConnectFlags flags)
 		{
 			this.dlg = dlg;
 			this.handlerId = handlerId;

--- a/wrap/APILookupGio.txt
+++ b/wrap/APILookupGio.txt
@@ -81,7 +81,7 @@ code: start
 			this,
 			"command-line",
 			cast(GCallback)&callBackScopedCommandLine,
-			&scopedOnCommandLineListeners[scopedOnCommandLineListeners.length - 1],
+			cast(void*)scopedOnCommandLineListeners[scopedOnCommandLineListeners.length - 1],
 			cast(GClosureNotify)&callBackScopedCommandLineDestroy,
 			connectFlags);
 		if (handlerId > 0)
@@ -93,14 +93,14 @@ code: start
 
 	extern(C) static int callBackScopedCommandLine(GApplication* applicationStruct, GApplicationCommandLine* commandLine, void* pWrapper)
 	{
-		ScopedOnCommandLineDelegateWrapper wrapper = *cast(ScopedOnCommandLineDelegateWrapper*)pWrapper;
+		ScopedOnCommandLineDelegateWrapper wrapper = cast(ScopedOnCommandLineDelegateWrapper)pWrapper;
 		return wrapper.dlg(scoped!ApplicationCommandLine(commandLine), wrapper.outer);
 	}
 	
 
 	extern(C) static void callBackScopedCommandLineDestroy(void* pWrapper, void* closure)
 	{
-		ScopedOnCommandLineDelegateWrapper source = *cast(ScopedOnCommandLineDelegateWrapper*)pWrapper;
+		ScopedOnCommandLineDelegateWrapper source = cast(ScopedOnCommandLineDelegateWrapper)pWrapper;
 		source.outer.internalRemoveOnCommandLine(source);
 	}
 

--- a/wrap/APILookupGio.txt
+++ b/wrap/APILookupGio.txt
@@ -45,7 +45,23 @@ implements: AppInfo
 
 struct: Application
 code: start
-int delegate(Scoped!ApplicationCommandLine, Application)[] scopedOnCommandLineListeners;
+
+	protected class ScopedOnCommandLineDelegateWrapper
+	{
+		int delegate(Scoped!ApplicationCommandLine, Application) dlg;
+		ulong handlerId;
+		ConnectFlags flags;
+
+		this(int delegate(Scoped!ApplicationCommandLine, Application) dlg, ulong handlerId, ConnectFlags flags) 
+		{
+			this.dlg = dlg;
+			this.handlerId = handlerId;
+			this.flags = flags;
+		}
+	}
+	
+	protected ScopedOnCommandLineDelegateWrapper[] scopedOnCommandLineListeners;
+
 	/**
 	 * The ::command-line signal is emitted on the primary instance when
 	 * a commandline is not handled locally. See g_application_run() and
@@ -58,25 +74,56 @@ int delegate(Scoped!ApplicationCommandLine, Application)[] scopedOnCommandLineLi
 	 * Return: An integer that is set as the exit status for the calling
 	 *     process. See g_application_command_line_set_exit_status().
 	 */
-	void addOnCommandLine(int delegate(Scoped!ApplicationCommandLine, Application) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
+	ulong addOnCommandLine(int delegate(Scoped!ApplicationCommandLine, Application) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
 	{
-		if ( "command-line-scoped" !in connectedSignals )
+		scopedOnCommandLineListeners ~= new ScopedOnCommandLineDelegateWrapper(dlg, 0, connectFlags);
+		ulong handlerId = Signals.connectData(
+			this,
+			"command-line",
+			cast(GCallback)&callBackScopedCommandLine,
+			&scopedOnCommandLineListeners[scopedOnCommandLineListeners.length - 1],
+			cast(GClosureNotify)&callBackScopedCommandLineDestroy,
+			connectFlags);
+		if (handlerId > 0)
+			scopedOnCommandLineListeners[scopedOnCommandLineListeners.length - 1].handlerId = handlerId;
+		else
+			internalRemoveOnCommandLine(scopedOnCommandLineListeners[scopedOnCommandLineListeners.length - 1]);
+		return handlerId;
+	}
+
+	extern(C) static int callBackScopedCommandLine(GApplication* applicationStruct, GApplicationCommandLine* commandLine, void* pWrapper)
+	{
+		ScopedOnCommandLineDelegateWrapper wrapper = *cast(ScopedOnCommandLineDelegateWrapper*)pWrapper;
+		return wrapper.dlg(scoped!ApplicationCommandLine(commandLine), wrapper.outer);
+	}
+	
+
+	extern(C) static void callBackScopedCommandLineDestroy(void* pWrapper, void* closure)
+	{
+		ScopedOnCommandLineDelegateWrapper source = *cast(ScopedOnCommandLineDelegateWrapper*)pWrapper;
+		source.outer.internalRemoveOnCommandLine(source);
+	}
+
+	void removeOnCommandLine(int delegate(Scoped!ApplicationCommandLine, Application) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
+	{
+		foreach(index, wrapper; scopedOnCommandLineListeners)
+		if (wrapper.dlg == dlg && wrapper.flags == connectFlags && wrapper.handlerId > 0)
+			Signals.handlerDisconnect(this, wrapper.handlerId);
+	}
+
+	protected void internalRemoveOnCommandLine(ScopedOnCommandLineDelegateWrapper source)
+	{
+		foreach(index, wrapper; scopedOnCommandLineListeners)
 		{
-			Signals.connectData(
-				this,
-				"command-line",
-				cast(GCallback)&callBackScopedCommandLine,
-				cast(void*)this,
-				null,
-				connectFlags);
-			connectedSignals["command-line-scoped"] = 1;
+			if (wrapper.dlg == source.dlg && wrapper.flags == source.flags)
+			{
+				scopedOnCommandLineListeners[index] = null;
+				scopedOnCommandLineListeners = std.algorithm.remove(scopedOnCommandLineListeners, index);
+				break;
+			}
 		}
-		scopedOnCommandLineListeners ~= dlg;
 	}
-	extern(C) static int callBackScopedCommandLine(GApplication* applicationStruct, GApplicationCommandLine* commandLine, Application _application)
-	{
-		return _application.onCommandLineListeners[0](scoped!ApplicationCommandLine(commandLine), _application);
-	}
+
 code: end
 
 struct: BufferedInputStream

--- a/wrap/APILookupGio.txt
+++ b/wrap/APILookupGio.txt
@@ -45,21 +45,19 @@ implements: AppInfo
 
 struct: Application
 code: start
-
 	protected class ScopedOnCommandLineDelegateWrapper
 	{
 		int delegate(Scoped!ApplicationCommandLine, Application) dlg;
 		ulong handlerId;
 		ConnectFlags flags;
-
-		this(int delegate(Scoped!ApplicationCommandLine, Application) dlg, ulong handlerId, ConnectFlags flags) 
+		this(int delegate(Scoped!ApplicationCommandLine, Application) dlg, ulong handlerId, ConnectFlags flags)
 		{
 			this.dlg = dlg;
 			this.handlerId = handlerId;
 			this.flags = flags;
 		}
 	}
-	
+
 	protected ScopedOnCommandLineDelegateWrapper[] scopedOnCommandLineListeners;
 
 	/**
@@ -74,48 +72,34 @@ code: start
 	 * Return: An integer that is set as the exit status for the calling
 	 *     process. See g_application_command_line_set_exit_status().
 	 */
-	ulong addOnCommandLine(int delegate(Scoped!ApplicationCommandLine, Application) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
+	gulong addOnCommandLine(int delegate(Scoped!ApplicationCommandLine, Application) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
 	{
 		scopedOnCommandLineListeners ~= new ScopedOnCommandLineDelegateWrapper(dlg, 0, connectFlags);
-		ulong handlerId = Signals.connectData(
+		onCommandLineListeners[scopedOnCommandLineListeners.length - 1].handlerId = Signals.connectData(
 			this,
 			"command-line",
 			cast(GCallback)&callBackScopedCommandLine,
 			cast(void*)scopedOnCommandLineListeners[scopedOnCommandLineListeners.length - 1],
 			cast(GClosureNotify)&callBackScopedCommandLineDestroy,
 			connectFlags);
-		if (handlerId > 0)
-			scopedOnCommandLineListeners[scopedOnCommandLineListeners.length - 1].handlerId = handlerId;
-		else
-			internalRemoveOnCommandLine(scopedOnCommandLineListeners[scopedOnCommandLineListeners.length - 1]);
-		return handlerId;
+		return scopedOnCommandLineListeners[scopedOnCommandLineListeners.length - 1].handlerId;
 	}
-
-	extern(C) static int callBackScopedCommandLine(GApplication* applicationStruct, GApplicationCommandLine* commandLine, void* pWrapper)
+	
+	extern(C) static int callBackScopedCommandLine(GApplication* applicationStruct, GApplicationCommandLine* commandLine, ScopedOnCommandLineDelegateWrapper wrapper)
 	{
-		ScopedOnCommandLineDelegateWrapper wrapper = cast(ScopedOnCommandLineDelegateWrapper)pWrapper;
 		return wrapper.dlg(scoped!ApplicationCommandLine(commandLine), wrapper.outer);
 	}
 	
-
-	extern(C) static void callBackScopedCommandLineDestroy(void* pWrapper, void* closure)
+	extern(C) static void callBackScopedCommandLineDestroy(OnCommandLineDelegateWrapper wrapper, GClosure* closure)
 	{
-		ScopedOnCommandLineDelegateWrapper source = cast(ScopedOnCommandLineDelegateWrapper)pWrapper;
-		source.outer.internalRemoveOnCommandLine(source);
-	}
-
-	void removeOnCommandLine(int delegate(Scoped!ApplicationCommandLine, Application) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
-	{
-		foreach(index, wrapper; scopedOnCommandLineListeners)
-		if (wrapper.dlg == dlg && wrapper.flags == connectFlags && wrapper.handlerId > 0)
-			Signals.handlerDisconnect(this, wrapper.handlerId);
+		wrapper.outer.internalRemoveOnCommandLine(wrapper);
 	}
 
 	protected void internalRemoveOnCommandLine(ScopedOnCommandLineDelegateWrapper source)
 	{
 		foreach(index, wrapper; scopedOnCommandLineListeners)
 		{
-			if (wrapper.dlg == source.dlg && wrapper.flags == source.flags)
+			if (wrapper.dlg == source.dlg && wrapper.flags == source.flags && wrapper.handlerId == source.handlerId)
 			{
 				scopedOnCommandLineListeners[index] = null;
 				scopedOnCommandLineListeners = std.algorithm.remove(scopedOnCommandLineListeners, index);
@@ -123,7 +107,6 @@ code: start
 			}
 		}
 	}
-
 code: end
 
 struct: BufferedInputStream

--- a/wrap/APILookupGtk.txt
+++ b/wrap/APILookupGtk.txt
@@ -1074,9 +1074,20 @@ code: start
 		}
 	}
 
-	int[string] connectedSignals;
+	protected class OnChangedDelegateWrapper
+	{
+		void delegate(ComboBoxText) dlg;
+		ulong handlerId;
+		ConnectFlags flags;
+		this(void delegate(ComboBoxText) dlg, ulong handlerId, ConnectFlags flags)
+		{
+			this.dlg = dlg;
+			this.handlerId = handlerId;
+			this.flags = flags;
+		}
+	}
+	protected OnChangedDelegateWrapper[] onChangedListeners;
 
-	void delegate(ComboBoxText)[] onChangedListeners;
 	/**
 	 * The changed signal is emitted when the active
 	 * item is changed. The can be due to the user selecting
@@ -1087,46 +1098,72 @@ code: start
 	 *
 	 * Since: 2.4
 	 */
-	void addOnChanged(void delegate(ComboBoxText) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
+	gulong addOnChanged(void delegate(ComboBoxText) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
 	{
-		if ( "changed" !in connectedSignals )
-		{
-			Signals.connectData(
-				this,
-				"changed",
-				cast(GCallback)&callBackChanged,
-				cast(void*)this,
-				null,
-				connectFlags);
-			connectedSignals["changed"] = 1;
-		}
-		onChangedListeners ~= dlg;
+		onChangedListeners ~= new OnChangedDelegateWrapper(dlg, 0, connectFlags);
+		onChangedListeners[onChangedListeners.length - 1].handlerId = Signals.connectData(
+			this,
+			"changed",
+			cast(GCallback)&callBackChanged,
+			cast(void*)onChangedListeners[onChangedListeners.length - 1],
+			cast(GClosureNotify)&callBackChangedDestroy,
+			connectFlags);
+		return onChangedListeners[onChangedListeners.length - 1].handlerId;
 	}
-	extern(C) static void callBackChanged(GtkComboBoxText* ComboBoxTextStruct, ComboBoxText _ComboBoxText)
+	
+	extern(C) static void callBackChanged(GtkComboBoxText* comboboxTextStruct, OnChangedDelegateWrapper wrapper)
 	{
-		foreach ( void delegate(ComboBoxText) dlg; _ComboBoxText.onChangedListeners )
+		wrapper.dlg(wrapper.outer);
+	}
+	
+	extern(C) static void callBackChangedDestroy(OnChangedDelegateWrapper wrapper, GClosure* closure)
+	{
+		wrapper.outer.internalRemoveOnChanged(wrapper);
+	}
+
+	protected void internalRemoveOnChanged(OnChangedDelegateWrapper source)
+	{
+		foreach(index, wrapper; onChangedListeners)
 		{
-			dlg(_ComboBoxText);
+			if (wrapper.dlg == source.dlg && wrapper.flags == source.flags && wrapper.handlerId == source.handlerId)
+			{
+				onChangedListeners[index] = null;
+				onChangedListeners = std.algorithm.remove(onChangedListeners, index);
+				break;
+			}
 		}
 	}
 
-	string delegate(string, ComboBoxText)[] onFormatEntryTextListeners;
+	protected class OnFormatEntryTextDelegateWrapper
+	{
+		string delegate(string, ComboBoxText) dlg;
+		ulong handlerId;
+		ConnectFlags flags;
+		this(string delegate(string, ComboBoxText) dlg, ulong handlerId, ConnectFlags flags)
+		{
+			this.dlg = dlg;
+			this.handlerId = handlerId;
+			this.flags = flags;
+		}
+	}
+	protected OnFormatEntryTextDelegateWrapper[] onFormatEntryTextListeners;
+
 	/**
-	 * For combo boxes that are created with an entry (See GtkComboBoxText:has-entry).
+	 * For combo boxes that are created with an entry (See GtkComboBox:has-entry).
 	 *
 	 * A signal which allows you to change how the text displayed in a combo box's
 	 * entry is displayed.
 	 *
 	 * Connect a signal handler which returns an allocated string representing
 	 * @path. That string will then be used to set the text in the combo box's entry.
-	 * The default signal handler uses the text from the GtkComboBoxText::entry-text-column
+	 * The default signal handler uses the text from the GtkComboBox::entry-text-column
 	 * model column.
 	 *
 	 * Here's an example signal handler which fetches data from the model and
 	 * displays it in the entry.
 	 * |[<!-- language="C" -->
 	 * static gchar*
-	 * format_entry_text_callback (GtkComboBoxText *combo,
+	 * format_entry_text_callback (GtkComboBox *combo,
 	 * const gchar *path,
 	 * gpointer     user_data)
 	 * {
@@ -1149,31 +1186,60 @@ code: start
 	 *     path = the GtkTreePath string from the combo box's current model to format text for
 	 *
 	 * Return: a newly allocated string representing @path
-	 *     for the current GtkComboBoxText model.
+	 *     for the current GtkComboBox model.
 	 *
 	 * Since: 3.4
 	 */
-	void addOnFormatEntryText(string delegate(string, ComboBoxText) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
+	gulong addOnFormatEntryText(string delegate(string, ComboBoxText) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
 	{
-		if ( "format-entry-text" !in connectedSignals )
-		{
-			Signals.connectData(
-				this,
-				"format-entry-text",
-				cast(GCallback)&callBackFormatEntryText,
-				cast(void*)this,
-				null,
-				connectFlags);
-			connectedSignals["format-entry-text"] = 1;
-		}
-		onFormatEntryTextListeners ~= dlg;
+		onFormatEntryTextListeners ~= new OnFormatEntryTextDelegateWrapper(dlg, 0, connectFlags);
+		onFormatEntryTextListeners[onFormatEntryTextListeners.length - 1].handlerId = Signals.connectData(
+			this,
+			"format-entry-text",
+			cast(GCallback)&callBackFormatEntryText,
+			cast(void*)onFormatEntryTextListeners[onFormatEntryTextListeners.length - 1],
+			cast(GClosureNotify)&callBackFormatEntryTextDestroy,
+			connectFlags);
+		return onFormatEntryTextListeners[onFormatEntryTextListeners.length - 1].handlerId;
 	}
-	extern(C) static string callBackFormatEntryText(GtkComboBoxText* ComboBoxTextStruct, char* path, ComboBoxText _ComboBoxText)
+	
+	extern(C) static string callBackFormatEntryText(GtkComboBoxText* comboboxStructText, char* path,OnFormatEntryTextDelegateWrapper wrapper)
 	{
-		return _ComboBoxText.onFormatEntryTextListeners[0](Str.toString(path), _ComboBoxText);
+		return wrapper.dlg(Str.toString(path), wrapper.outer);
+	}
+	
+	extern(C) static void callBackFormatEntryTextDestroy(OnFormatEntryTextDelegateWrapper wrapper, GClosure* closure)
+	{
+		wrapper.outer.internalRemoveOnFormatEntryText(wrapper);
 	}
 
-	void delegate(GtkScrollType, ComboBoxText)[] onMoveActiveListeners;
+	protected void internalRemoveOnFormatEntryText(OnFormatEntryTextDelegateWrapper source)
+	{
+		foreach(index, wrapper; onFormatEntryTextListeners)
+		{
+			if (wrapper.dlg == source.dlg && wrapper.flags == source.flags && wrapper.handlerId == source.handlerId)
+			{
+				onFormatEntryTextListeners[index] = null;
+				onFormatEntryTextListeners = std.algorithm.remove(onFormatEntryTextListeners, index);
+				break;
+			}
+		}
+	}
+
+	protected class OnMoveActiveDelegateWrapper
+	{
+		void delegate(GtkScrollType, ComboBoxText) dlg;
+		ulong handlerId;
+		ConnectFlags flags;
+		this(void delegate(GtkScrollType, ComboBoxText) dlg, ulong handlerId, ConnectFlags flags)
+		{
+			this.dlg = dlg;
+			this.handlerId = handlerId;
+			this.flags = flags;
+		}
+	}
+	protected OnMoveActiveDelegateWrapper[] onMoveActiveListeners;
+
 	/**
 	 * The ::move-active signal is a
 	 * [keybinding signal][GtkBindingSignal]
@@ -1184,30 +1250,56 @@ code: start
 	 *
 	 * Since: 2.12
 	 */
-	void addOnMoveActive(void delegate(GtkScrollType, ComboBoxText) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
+	gulong addOnMoveActive(void delegate(GtkScrollType, ComboBoxText) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
 	{
-		if ( "move-active" !in connectedSignals )
-		{
-			Signals.connectData(
-				this,
-				"move-active",
-				cast(GCallback)&callBackMoveActive,
-				cast(void*)this,
-				null,
-				connectFlags);
-			connectedSignals["move-active"] = 1;
-		}
-		onMoveActiveListeners ~= dlg;
+		onMoveActiveListeners ~= new OnMoveActiveDelegateWrapper(dlg, 0, connectFlags);
+		onMoveActiveListeners[onMoveActiveListeners.length - 1].handlerId = Signals.connectData(
+			this,
+			"move-active",
+			cast(GCallback)&callBackMoveActive,
+			cast(void*)onMoveActiveListeners[onMoveActiveListeners.length - 1],
+			cast(GClosureNotify)&callBackMoveActiveDestroy,
+			connectFlags);
+		return onMoveActiveListeners[onMoveActiveListeners.length - 1].handlerId;
 	}
-	extern(C) static void callBackMoveActive(GtkComboBoxText* ComboBoxTextStruct, GtkScrollType scrollType, ComboBoxText _ComboBoxText)
+	
+	extern(C) static void callBackMoveActive(GtkComboBoxText* comboboxTextStruct, GtkScrollType scrollType,OnMoveActiveDelegateWrapper wrapper)
 	{
-		foreach ( void delegate(GtkScrollType, ComboBoxText) dlg; _ComboBoxText.onMoveActiveListeners )
+		wrapper.dlg(scrollType, wrapper.outer);
+	}
+	
+	extern(C) static void callBackMoveActiveDestroy(OnMoveActiveDelegateWrapper wrapper, GClosure* closure)
+	{
+		wrapper.outer.internalRemoveOnMoveActive(wrapper);
+	}
+
+	protected void internalRemoveOnMoveActive(OnMoveActiveDelegateWrapper source)
+	{
+		foreach(index, wrapper; onMoveActiveListeners)
 		{
-			dlg(scrollType, _ComboBoxText);
+			if (wrapper.dlg == source.dlg && wrapper.flags == source.flags && wrapper.handlerId == source.handlerId)
+			{
+				onMoveActiveListeners[index] = null;
+				onMoveActiveListeners = std.algorithm.remove(onMoveActiveListeners, index);
+				break;
+			}
 		}
 	}
 
-	bool delegate(ComboBoxText)[] onPopdownListeners;
+	protected class OnPopdownDelegateWrapper
+	{
+		bool delegate(ComboBoxText) dlg;
+		ulong handlerId;
+		ConnectFlags flags;
+		this(bool delegate(ComboBoxText) dlg, ulong handlerId, ConnectFlags flags)
+		{
+			this.dlg = dlg;
+			this.handlerId = handlerId;
+			this.flags = flags;
+		}
+	}
+	protected OnPopdownDelegateWrapper[] onPopdownListeners;
+
 	/**
 	 * The ::popdown signal is a
 	 * [keybinding signal][GtkBindingSignal]
@@ -1217,35 +1309,57 @@ code: start
 	 *
 	 * Since: 2.12
 	 */
-	void addOnPopdown(bool delegate(ComboBoxText) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
+	gulong addOnPopdown(bool delegate(ComboBoxText) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
 	{
-		if ( "popdown" !in connectedSignals )
-		{
-			Signals.connectData(
-				this,
-				"popdown",
-				cast(GCallback)&callBackPopdown,
-				cast(void*)this,
-				null,
-				connectFlags);
-			connectedSignals["popdown"] = 1;
-		}
-		onPopdownListeners ~= dlg;
+		onPopdownListeners ~= new OnPopdownDelegateWrapper(dlg, 0, connectFlags);
+		onPopdownListeners[onPopdownListeners.length - 1].handlerId = Signals.connectData(
+			this,
+			"popdown",
+			cast(GCallback)&callBackPopdown,
+			cast(void*)onPopdownListeners[onPopdownListeners.length - 1],
+			cast(GClosureNotify)&callBackPopdownDestroy,
+			connectFlags);
+		return onPopdownListeners[onPopdownListeners.length - 1].handlerId;
 	}
-	extern(C) static int callBackPopdown(GtkComboBoxText* ComboBoxTextStruct, ComboBoxText _ComboBoxText)
+	
+	extern(C) static int callBackPopdown(GtkComboBoxText* comboboxTextStruct,OnPopdownDelegateWrapper wrapper)
 	{
-		foreach ( bool delegate(ComboBoxText) dlg; _ComboBoxText.onPopdownListeners )
+		return wrapper.dlg(wrapper.outer);
+	}
+	
+	extern(C) static void callBackPopdownDestroy(OnPopdownDelegateWrapper wrapper, GClosure* closure)
+	{
+		wrapper.outer.internalRemoveOnPopdown(wrapper);
+	}
+
+	protected void internalRemoveOnPopdown(OnPopdownDelegateWrapper source)
+	{
+		foreach(index, wrapper; onPopdownListeners)
 		{
-			if ( dlg(_ComboBoxText) )
+			if (wrapper.dlg == source.dlg && wrapper.flags == source.flags && wrapper.handlerId == source.handlerId)
 			{
-				return 1;
+				onPopdownListeners[index] = null;
+				onPopdownListeners = std.algorithm.remove(onPopdownListeners, index);
+				break;
 			}
 		}
-
-		return 0;
 	}
 
-	void delegate(ComboBoxText)[] onPopupListeners;
+
+	protected class OnPopupDelegateWrapper
+	{
+		void delegate(ComboBoxText) dlg;
+		ulong handlerId;
+		ConnectFlags flags;
+		this(void delegate(ComboBoxText) dlg, ulong handlerId, ConnectFlags flags)
+		{
+			this.dlg = dlg;
+			this.handlerId = handlerId;
+			this.flags = flags;
+		}
+	}
+	protected OnPopupDelegateWrapper[] onPopupListeners;
+
 	/**
 	 * The ::popup signal is a
 	 * [keybinding signal][GtkBindingSignal]
@@ -1255,28 +1369,42 @@ code: start
 	 *
 	 * Since: 2.12
 	 */
-	void addOnPopup(void delegate(ComboBoxText) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
+	gulong addOnPopup(void delegate(ComboBoxText) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
 	{
-		if ( "popup" !in connectedSignals )
-		{
-			Signals.connectData(
-				this,
-				"popup",
-				cast(GCallback)&callBackPopup,
-				cast(void*)this,
-				null,
-				connectFlags);
-			connectedSignals["popup"] = 1;
-		}
-		onPopupListeners ~= dlg;
+		onPopupListeners ~= new OnPopupDelegateWrapper(dlg, 0, connectFlags);
+		onPopupListeners[onPopupListeners.length - 1].handlerId = Signals.connectData(
+			this,
+			"popup",
+			cast(GCallback)&callBackPopup,
+			cast(void*)onPopupListeners[onPopupListeners.length - 1],
+			cast(GClosureNotify)&callBackPopupDestroy,
+			connectFlags);
+		return onPopupListeners[onPopupListeners.length - 1].handlerId;
 	}
-	extern(C) static void callBackPopup(GtkComboBoxText* ComboBoxTextStruct, ComboBoxText _ComboBoxText)
+	
+	extern(C) static void callBackPopup(GtkComboBoxText* comboboxTextStruct,OnPopupDelegateWrapper wrapper)
 	{
-		foreach ( void delegate(ComboBoxText) dlg; _ComboBoxText.onPopupListeners )
+		wrapper.dlg(wrapper.outer);
+	}
+	
+	extern(C) static void callBackPopupDestroy(OnPopupDelegateWrapper wrapper, GClosure* closure)
+	{
+		wrapper.outer.internalRemoveOnPopup(wrapper);
+	}
+
+	protected void internalRemoveOnPopup(OnPopupDelegateWrapper source)
+	{
+		foreach(index, wrapper; onPopupListeners)
 		{
-			dlg(_ComboBoxText);
+			if (wrapper.dlg == source.dlg && wrapper.flags == source.flags && wrapper.handlerId == source.handlerId)
+			{
+				onPopupListeners[index] = null;
+				onPopupListeners = std.algorithm.remove(onPopupListeners, index);
+				break;
+			}
 		}
 	}
+
 code: end
 
 struct: Container

--- a/wrap/APILookupGtk.txt
+++ b/wrap/APILookupGtk.txt
@@ -1077,9 +1077,9 @@ code: start
 	protected class OnChangedDelegateWrapper
 	{
 		void delegate(ComboBoxText) dlg;
-		ulong handlerId;
+		gulong handlerId;
 		ConnectFlags flags;
-		this(void delegate(ComboBoxText) dlg, ulong handlerId, ConnectFlags flags)
+		this(void delegate(ComboBoxText) dlg, gulong handlerId, ConnectFlags flags)
 		{
 			this.dlg = dlg;
 			this.handlerId = handlerId;
@@ -1137,9 +1137,9 @@ code: start
 	protected class OnFormatEntryTextDelegateWrapper
 	{
 		string delegate(string, ComboBoxText) dlg;
-		ulong handlerId;
+		gulong handlerId;
 		ConnectFlags flags;
-		this(string delegate(string, ComboBoxText) dlg, ulong handlerId, ConnectFlags flags)
+		this(string delegate(string, ComboBoxText) dlg, gulong handlerId, ConnectFlags flags)
 		{
 			this.dlg = dlg;
 			this.handlerId = handlerId;
@@ -1229,9 +1229,9 @@ code: start
 	protected class OnMoveActiveDelegateWrapper
 	{
 		void delegate(GtkScrollType, ComboBoxText) dlg;
-		ulong handlerId;
+		gulong handlerId;
 		ConnectFlags flags;
-		this(void delegate(GtkScrollType, ComboBoxText) dlg, ulong handlerId, ConnectFlags flags)
+		this(void delegate(GtkScrollType, ComboBoxText) dlg, gulong handlerId, ConnectFlags flags)
 		{
 			this.dlg = dlg;
 			this.handlerId = handlerId;
@@ -1289,9 +1289,9 @@ code: start
 	protected class OnPopdownDelegateWrapper
 	{
 		bool delegate(ComboBoxText) dlg;
-		ulong handlerId;
+		gulong handlerId;
 		ConnectFlags flags;
-		this(bool delegate(ComboBoxText) dlg, ulong handlerId, ConnectFlags flags)
+		this(bool delegate(ComboBoxText) dlg, gulong handlerId, ConnectFlags flags)
 		{
 			this.dlg = dlg;
 			this.handlerId = handlerId;
@@ -1349,9 +1349,9 @@ code: start
 	protected class OnPopupDelegateWrapper
 	{
 		void delegate(ComboBoxText) dlg;
-		ulong handlerId;
+		gulong handlerId;
 		ConnectFlags flags;
-		this(void delegate(ComboBoxText) dlg, ulong handlerId, ConnectFlags flags)
+		this(void delegate(ComboBoxText) dlg, gulong handlerId, ConnectFlags flags)
 		{
 			this.dlg = dlg;
 			this.handlerId = handlerId;
@@ -5353,9 +5353,9 @@ code: start
 	protected class ScopedOnDrawDelegateWrapper
 	{
 		bool delegate(Scoped!Context, Widget) dlg;
-		ulong handlerId;
+		gulong handlerId;
 		ConnectFlags flags;
-		this(bool delegate(Scoped!Context, Widget) dlg, ulong handlerId, ConnectFlags flags)
+		this(bool delegate(Scoped!Context, Widget) dlg, gulong handlerId, ConnectFlags flags)
 		{
 			this.dlg = dlg;
 			this.handlerId = handlerId;
@@ -5430,9 +5430,9 @@ code: start
 	protected class OnDrawDelegateWrapper
 	{
 		bool delegate(Context, Widget) dlg;
-		ulong handlerId;
+		gulong handlerId;
 		ConnectFlags flags;
-		this(bool delegate(Context, Widget) dlg, ulong handlerId, ConnectFlags flags)
+		this(bool delegate(Context, Widget) dlg, gulong handlerId, ConnectFlags flags)
 		{
 			this.dlg = dlg;
 			this.handlerId = handlerId;

--- a/wrap/APILookupGtk.txt
+++ b/wrap/APILookupGtk.txt
@@ -5222,113 +5222,160 @@ code: start
 		return 0;
 	}
 
-	bool delegate(Scoped!Context, Widget)[] scopedOnDrawListeners;
-	/**
-	 * This signal is emitted when a widget is supposed to render itself.
-	 * The widget's top left corner must be painted at the origin of
-	 * the passed in context and be sized to the values returned by
-	 * getAllocatedWidth() and getAllocatedHeight().
-	 *
-	 * Signal handlers connected to this signal can modify the cairo
-	 * context passed as cr in any way they like and don't need to
-	 * restore it. The signal emission takes care of calling Context.save()
-	 * before and Context.restore() after invoking the handler.
-	 *
-	 * The signal handler will get a cr with a clip region already set to the
-	 * widget's dirty region, i.e. to the area that needs repainting. Complicated
-	 * widgets that want to avoid redrawing themselves completely can get the full
-	 * extents of the clip region with gdk.cairo.getClipRectangle(), or they can
-	 * get a finer-grained representation of the dirty region with
-	 * Context.copyClipRectangleList().
-	 *
-	 * Return true to stop other handlers from being invoked for the event,
-	 * false to propagate the event further.
-	 *
-	 * Since 3.0
-	 */
-	void addOnDraw(bool delegate(Scoped!Context, Widget) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
+	protected class ScopedOnDrawDelegateWrapper
 	{
-		if ( !("draw-scoped" in connectedSignals) )
+		bool delegate(Scoped!Context, Widget) dlg;
+		ulong handlerId;
+		ConnectFlags flags;
+		this(bool delegate(Scoped!Context, Widget) dlg, ulong handlerId, ConnectFlags flags)
 		{
-			Signals.connectData(
-				this,
-				"draw",
-				cast(GCallback)&callBackScopedDraw,
-				cast(void*)this,
-				null,
-				connectFlags);
-			connectedSignals["draw-scoped"] = 1;
+			this.dlg = dlg;
+			this.handlerId = handlerId;
+			this.flags = flags;
 		}
-		scopedOnDrawListeners ~= dlg;
 	}
-	extern(C) static int callBackScopedDraw(GtkWidget* widgetStruct, cairo_t* cr, Widget _widget)
+	protected ScopedOnDrawDelegateWrapper[] scopedOnDrawListeners;
+
+	/**
+		* This signal is emitted when a widget is supposed to render itself.
+		* The @widget's top left corner must be painted at the origin of
+		* the passed in context and be sized to the values returned by
+		* gtk_widget_get_allocated_width() and
+		* gtk_widget_get_allocated_height().
+		*
+		* Signal handlers connected to this signal can modify the cairo
+		* context passed as @cr in any way they like and don't need to
+		* restore it. The signal emission takes care of calling cairo_save()
+		* before and cairo_restore() after invoking the handler.
+		*
+		* The signal handler will get a @cr with a clip region already set to the
+		* widget's dirty region, i.e. to the area that needs repainting.  Complicated
+		* widgets that want to avoid redrawing themselves completely can get the full
+		* extents of the clip region with gdk_cairo_get_clip_rectangle(), or they can
+		* get a finer-grained representation of the dirty region with
+		* cairo_copy_clip_rectangle_list().
+		*
+		* Params:
+		*     cr = the cairo context to draw to
+		*
+		* Return: %TRUE to stop other handlers from being invoked for the event.
+		*     %FALSE to propagate the event further.
+		*
+		* Since: 3.0
+		*/
+	gulong addOnDraw(bool delegate(Scoped!Context, Widget) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
 	{
-		foreach ( bool delegate(Scoped!Context, Widget) dlg ; _widget.scopedOnDrawListeners )
+		scopedOnDrawListeners ~= new ScopedOnDrawDelegateWrapper(dlg, 0, connectFlags);
+		scopedOnDrawListeners[scopedOnDrawListeners.length - 1].handlerId = Signals.connectData(
+			this,
+			"draw",
+			cast(GCallback)&callBackScopedDraw,
+			cast(void*)scopedOnDrawListeners[scopedOnDrawListeners.length - 1],
+			cast(GClosureNotify)&callBackDrawScopedDestroy,
+			connectFlags);
+		return scopedOnDrawListeners[scopedOnDrawListeners.length - 1].handlerId;
+	}
+	
+	extern(C) static int callBackScopedDraw(GtkWidget* widgetStruct, cairo_t* cr, ScopedOnDrawDelegateWrapper wrapper)
+	{
+		return wrapper.dlg(scoped!Context(cr), wrapper.outer);
+	}
+	
+	extern(C) static void callBackDrawScopedDestroy(ScopedOnDrawDelegateWrapper wrapper, GClosure* closure)
+	{
+		wrapper.outer.internalRemoveOnDraw(wrapper);
+	}
+
+	protected void internalRemoveOnDraw(ScopedOnDrawDelegateWrapper source)
+	{
+		foreach(index, wrapper; scopedOnDrawListeners)
 		{
-			if ( dlg(scoped!Context(cr), _widget) )
+			if (wrapper.dlg == source.dlg && wrapper.flags == source.flags && wrapper.handlerId == source.handlerId)
 			{
-				return 1;
+				scopedOnDrawListeners[index] = null;
+				scopedOnDrawListeners = std.algorithm.remove(scopedOnDrawListeners, index);
+				break;
 			}
 		}
-
-		return 0;
 	}
 
-	bool delegate(Context, Widget)[] onDrawListeners;
-	/**
-	 * This signal is emitted when a widget is supposed to render itself.
-	 * The @widget's top left corner must be painted at the origin of
-	 * the passed in context and be sized to the values returned by
-	 * gtk_widget_get_allocated_width() and
-	 * gtk_widget_get_allocated_height().
-	 *
-	 * Signal handlers connected to this signal can modify the cairo
-	 * context passed as @cr in any way they like and don't need to
-	 * restore it. The signal emission takes care of calling cairo_save()
-	 * before and cairo_restore() after invoking the handler.
-	 *
-	 * The signal handler will get a @cr with a clip region already set to the
-	 * widget's dirty region, i.e. to the area that needs repainting.  Complicated
-	 * widgets that want to avoid redrawing themselves completely can get the full
-	 * extents of the clip region with gdk_cairo_get_clip_rectangle(), or they can
-	 * get a finer-grained representation of the dirty region with
-	 * cairo_copy_clip_rectangle_list().
-	 *
-	 * Params:
-	 *     cr = the cairo context to draw to
-	 *
-	 * Return: %TRUE to stop other handlers from being invoked for the event.
-	 *     % %FALSE to propagate the event further.
-	 *
-	 * Since: 3.0
-	 */
-	deprecated void addOnDraw(bool delegate(Context, Widget) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
+	protected class OnDrawDelegateWrapper
 	{
-		if ( "draw" !in connectedSignals )
+		bool delegate(Context, Widget) dlg;
+		ulong handlerId;
+		ConnectFlags flags;
+		this(bool delegate(Context, Widget) dlg, ulong handlerId, ConnectFlags flags)
 		{
-			Signals.connectData(
-				this,
-				"draw",
-				cast(GCallback)&callBackDraw,
-				cast(void*)this,
-				null,
-				connectFlags);
-			connectedSignals["draw"] = 1;
+			this.dlg = dlg;
+			this.handlerId = handlerId;
+			this.flags = flags;
 		}
-		onDrawListeners ~= dlg;
 	}
-	extern(C) static int callBackDraw(GtkWidget* widgetStruct, cairo_t* cr, Widget _widget)
+	protected OnDrawDelegateWrapper[] onDrawListeners;
+
+	/**
+		* This signal is emitted when a widget is supposed to render itself.
+		* The @widget's top left corner must be painted at the origin of
+		* the passed in context and be sized to the values returned by
+		* gtk_widget_get_allocated_width() and
+		* gtk_widget_get_allocated_height().
+		*
+		* Signal handlers connected to this signal can modify the cairo
+		* context passed as @cr in any way they like and don't need to
+		* restore it. The signal emission takes care of calling cairo_save()
+		* before and cairo_restore() after invoking the handler.
+		*
+		* The signal handler will get a @cr with a clip region already set to the
+		* widget's dirty region, i.e. to the area that needs repainting.  Complicated
+		* widgets that want to avoid redrawing themselves completely can get the full
+		* extents of the clip region with gdk_cairo_get_clip_rectangle(), or they can
+		* get a finer-grained representation of the dirty region with
+		* cairo_copy_clip_rectangle_list().
+		*
+		* Params:
+		*     cr = the cairo context to draw to
+		*
+		* Return: %TRUE to stop other handlers from being invoked for the event.
+		*     %FALSE to propagate the event further.
+		*
+		* Since: 3.0
+		*/
+	deprecated gulong addOnDraw(bool delegate(Context, Widget) dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)
 	{
-		foreach ( bool delegate(Context, Widget) dlg; _widget.onDrawListeners )
+		onDrawListeners ~= new OnDrawDelegateWrapper(dlg, 0, connectFlags);
+		onDrawListeners[onDrawListeners.length - 1].handlerId = Signals.connectData(
+			this,
+			"draw",
+			cast(GCallback)&callBackDraw,
+			cast(void*)onDrawListeners[onDrawListeners.length - 1],
+			cast(GClosureNotify)&callBackDrawDestroy,
+			connectFlags);
+		return onDrawListeners[onDrawListeners.length - 1].handlerId;
+	}
+	
+	extern(C) static int callBackDraw(GtkWidget* widgetStruct, cairo_t* cr,OnDrawDelegateWrapper wrapper)
+	{
+		return wrapper.dlg(new Context(cr), wrapper.outer);
+	}
+	
+	extern(C) static void callBackDrawDestroy(OnDrawDelegateWrapper wrapper, GClosure* closure)
+	{
+		wrapper.outer.internalRemoveOnDraw(wrapper);
+	}
+
+	protected void internalRemoveOnDraw(OnDrawDelegateWrapper source)
+	{
+		foreach(index, wrapper; onDrawListeners)
 		{
-			if ( dlg(new Context(cr), _widget) )
+			if (wrapper.dlg == source.dlg && wrapper.flags == source.flags && wrapper.handlerId == source.handlerId)
 			{
-				return 1;
+				onDrawListeners[index] = null;
+				onDrawListeners = std.algorithm.remove(onDrawListeners, index);
+				break;
 			}
 		}
-
-		return 0;
 	}
+
 code: end
 
 struct: WidgetPath

--- a/wrap/utils/GtkFunction.d
+++ b/wrap/utils/GtkFunction.d
@@ -986,7 +986,7 @@ final class GtkFunction
 	{
 		assert(type == GtkFunctionType.Signal);
 
-		string buff = "private struct " ~ getDelegateWrapperName();
+		string buff = "protected struct " ~ getDelegateWrapperName();
 		buff ~= " {";
 		if ( strct.type == GtkStructType.Interface ) {
 			buff ~= strct.name ~ "IF " ~ tokenToGtkD(strct.name.toLower(), wrapper.aliasses, localAliases()) ~ ";";
@@ -1100,6 +1100,7 @@ final class GtkFunction
 		*/
 		buff ~= "return handlerId;";
 		buff ~= "}";
+		buff ~= "\n";
 
 		return buff;
 	}
@@ -1210,6 +1211,7 @@ final class GtkFunction
 
 	*/
 		buff ~= "}";
+		buff ~= "\n";
 		return buff;
 	}
 	

--- a/wrap/utils/GtkFunction.d
+++ b/wrap/utils/GtkFunction.d
@@ -1024,7 +1024,7 @@ final class GtkFunction
 		string[] buff;
 
 		writeDocs(buff);
-		buff ~= "ulong addOn"~ getSignalName() ~"("~ getDelegateDecleration() ~" dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)";
+		buff ~= "gulong addOn"~ getSignalName() ~"("~ getDelegateDecleration() ~" dlg, ConnectFlags connectFlags=cast(ConnectFlags)0)";
 
 		return buff;
 	}
@@ -1062,22 +1062,17 @@ final class GtkFunction
 			}
 		}
 
+		string wrapper = getDelegateWrapperArrayName() ~ "[" ~ getDelegateWrapperArrayName() ~ ".length - 1]";
+
 		buff ~= getDelegateWrapperArrayName ~ " ~= new " ~ getDelegateWrapperName ~ "(dlg, 0, connectFlags);";
-		buff ~= "ulong handlerId = Signals.connectData(";
+		buff ~= wrapper ~ ".handlerId = Signals.connectData(";
 		buff ~= "this,";
 		buff ~= "\""~ realName ~"\",";
 		buff ~= "cast(GCallback)&callBack"~ getSignalName() ~",";
-
-		string wrapper = getDelegateWrapperArrayName() ~ "[" ~ getDelegateWrapperArrayName() ~ ".length - 1]";
 		buff ~= "cast(void*)" ~ wrapper ~ ",";
-
 		buff ~= "cast(GClosureNotify)&callBack" ~ getSignalName() ~ "Destroy,";
 		buff ~= "connectFlags);";
-		buff ~= "if (handlerId > 0)";
-		buff ~= "{";
-		buff ~= wrapper ~ ".handlerId = handlerId;";
-		buff ~= "}";
-		buff ~= "return handlerId;";
+		buff ~= "return " ~ wrapper ~ ".handlerId;";
 		buff ~= "}";
 		buff ~= "\n";
 
@@ -1126,7 +1121,7 @@ final class GtkFunction
 		buff ~= "{";
 		buff ~= "foreach(index, wrapper; " ~ getDelegateWrapperArrayName() ~ ")";
 		buff ~= "{";
-		buff ~= "if (wrapper.dlg == source.dlg && wrapper.flags == source.flags)";
+		buff ~= "if (wrapper.dlg == source.dlg && wrapper.flags == source.flags && wrapper.handlerId == source.handlerId)";
 		buff ~= "{";
 		buff ~= getDelegateWrapperArrayName() ~ "[index] = null;";
 		buff ~= getDelegateWrapperArrayName() ~ " = std.algorithm.remove(" ~ getDelegateWrapperArrayName() ~ ", index);";
@@ -1151,7 +1146,7 @@ final class GtkFunction
 			~" callBack"~ getSignalName() ~"("~ getCallbackParams() ~")";
 
 		buff ~= "{";
-		buff ~= getDelegateWrapperName() ~ " wrapper = cast(" ~ getDelegateWrapperName() ~ ")pWrapper;";
+		//buff ~= getDelegateWrapperName() ~ " wrapper = cast(" ~ getDelegateWrapperName() ~ ")pWrapper;";
 
 		if ( type == "bool" )
 		{
@@ -1180,9 +1175,9 @@ final class GtkFunction
 	string[] getSignalDestroyCallback()
 	{
 		string[] buff;
-		buff ~= "extern(C) static void callBack"~ getSignalName() ~"Destroy(void* pWrapper, GClosure* closure)";
+		buff ~= "extern(C) static void callBack"~ getSignalName() ~"Destroy(" ~ getDelegateWrapperName() ~ " wrapper, GClosure* closure)";
 		buff ~= "{";
-		buff ~= getDelegateWrapperName() ~ " wrapper = cast(" ~ getDelegateWrapperName() ~ ")pWrapper;";
+		//buff ~= getDelegateWrapperName() ~ " wrapper = cast(" ~ getDelegateWrapperName() ~ ")pWrapper;";
 		buff ~= "wrapper.outer.internalRemoveOn" ~ getSignalName() ~ "(wrapper);";
 		buff ~= "}";
 		return buff;
@@ -1522,7 +1517,7 @@ final class GtkFunction
 				buff ~= stringToGtkD(", "~ param.type.name ~" "~ param.name, wrapper.aliasses, localAliases());
 		}
 
-		buff ~= ", void* pWrapper";
+		buff ~= "," ~ getDelegateWrapperName() ~ " wrapper";
 		return buff;
 	}
 

--- a/wrap/utils/GtkFunction.d
+++ b/wrap/utils/GtkFunction.d
@@ -976,17 +976,16 @@ final class GtkFunction
 		return "on" ~ getSignalName() ~ "Listeners";
 	}
 	
-	string getDelegateWrapperDeclaration()
+	string[] getDelegateWrapperDeclaration()
 	{
 		assert(type == GtkFunctionType.Signal);
 
-		string buff = "protected class " ~ getDelegateWrapperName();
-		buff ~= "\n";
+		string[] buff;
+		buff ~= "protected class " ~ getDelegateWrapperName();
 		buff ~= "{";
 		buff ~= getDelegateDecleration() ~ " dlg;";
 		buff ~= "ulong handlerId;";
 		buff ~= "ConnectFlags flags;";
-		buff ~= "\n";
 		buff ~= "this(" ~ getDelegateDecleration() ~ " dlg, ulong handlerId, ConnectFlags flags)";
 		buff ~= " {";
 		buff ~= "this.dlg = dlg;";
@@ -1085,6 +1084,7 @@ final class GtkFunction
 		return buff;
 	}
 
+	/*
 	string[] getRemoveListenerDeclaration() {
 		string[] buff;
 		// Should we document?
@@ -1108,6 +1108,7 @@ final class GtkFunction
 		buff ~= "}";
 		return buff;
 	}
+	*/
 
 	string[] getInternalRemoveListenerDeclaration() {
 		string[] buff;

--- a/wrap/utils/GtkFunction.d
+++ b/wrap/utils/GtkFunction.d
@@ -984,9 +984,9 @@ final class GtkFunction
 		buff ~= "protected class " ~ getDelegateWrapperName();
 		buff ~= "{";
 		buff ~= getDelegateDecleration() ~ " dlg;";
-		buff ~= "ulong handlerId;";
+		buff ~= "gulong handlerId;";
 		buff ~= "ConnectFlags flags;";
-		buff ~= "this(" ~ getDelegateDecleration() ~ " dlg, ulong handlerId, ConnectFlags flags)";
+		buff ~= "this(" ~ getDelegateDecleration() ~ " dlg, gulong handlerId, ConnectFlags flags)";
 		buff ~= " {";
 		buff ~= "this.dlg = dlg;";
 		buff ~= "this.handlerId = handlerId;";

--- a/wrap/utils/GtkFunction.d
+++ b/wrap/utils/GtkFunction.d
@@ -1070,7 +1070,7 @@ final class GtkFunction
 		buff ~= "cast(GCallback)&callBack"~ getSignalName() ~",";
 
 		string wrapper = getDelegateWrapperArrayName() ~ "[" ~ getDelegateWrapperArrayName() ~ ".length - 1]";
-		buff ~= "&" ~ wrapper ~ ",";
+		buff ~= "cast(void*)" ~ wrapper ~ ",";
 
 		buff ~= "cast(GClosureNotify)&callBack" ~ getSignalName() ~ "Destroy,";
 		buff ~= "connectFlags);";
@@ -1150,7 +1150,7 @@ final class GtkFunction
 			~" callBack"~ getSignalName() ~"("~ getCallbackParams() ~")";
 
 		buff ~= "{";
-		buff ~= getDelegateWrapperName() ~ " wrapper = *cast(" ~ getDelegateWrapperName() ~ "*)pWrapper;";
+		buff ~= getDelegateWrapperName() ~ " wrapper = cast(" ~ getDelegateWrapperName() ~ ")pWrapper;";
 
 		if ( type == "bool" )
 		{
@@ -1181,7 +1181,7 @@ final class GtkFunction
 		string[] buff;
 		buff ~= "extern(C) static void callBack"~ getSignalName() ~"Destroy(void* pWrapper, GClosure* closure)";
 		buff ~= "{";
-		buff ~= getDelegateWrapperName() ~ " wrapper = *cast(" ~ getDelegateWrapperName() ~ "*)pWrapper;";
+		buff ~= getDelegateWrapperName() ~ " wrapper = cast(" ~ getDelegateWrapperName() ~ ")pWrapper;";
 		buff ~= "wrapper.outer.internalRemoveOn" ~ getSignalName() ~ "(wrapper);";
 		buff ~= "}";
 		return buff;

--- a/wrap/utils/GtkFunction.d
+++ b/wrap/utils/GtkFunction.d
@@ -1075,9 +1075,9 @@ final class GtkFunction
 		buff ~= "cast(GClosureNotify)&callBack" ~ getSignalName() ~ "Destroy,";
 		buff ~= "connectFlags);";
 		buff ~= "if (handlerId > 0)";
+		buff ~= "{";
 		buff ~= wrapper ~ ".handlerId = handlerId;";
-		buff ~= "else";
-		buff ~= "internalRemoveOn" ~ getSignalName ~ "(" ~ wrapper ~ ");";
+		buff ~= "}";
 		buff ~= "return handlerId;";
 		buff ~= "}";
 		buff ~= "\n";
@@ -1179,10 +1179,10 @@ final class GtkFunction
 	string[] getSignalDestroyCallback()
 	{
 		string[] buff;
-		buff ~= "extern(C) static void callBack"~ getSignalName() ~"Destroy(void* pWrapper, void* closure)";
+		buff ~= "extern(C) static void callBack"~ getSignalName() ~"Destroy(void* pWrapper, GClosure* closure)";
 		buff ~= "{";
-		buff ~= getDelegateWrapperName() ~ " source = *cast(" ~ getDelegateWrapperName() ~ "*)pWrapper;";
-		buff ~= "source.outer.internalRemoveOn" ~ getSignalName() ~ "(source);";
+		buff ~= getDelegateWrapperName() ~ " wrapper = *cast(" ~ getDelegateWrapperName() ~ "*)pWrapper;";
+		buff ~= "wrapper.outer.internalRemoveOn" ~ getSignalName() ~ "(wrapper);";
 		buff ~= "}";
 		return buff;
 	}

--- a/wrap/utils/GtkStruct.d
+++ b/wrap/utils/GtkStruct.d
@@ -452,17 +452,16 @@ final class GtkStruct
 				buff ~= "\n";
 				buff ~= indenter.format(func.getAddListenerDeclaration());
 				buff ~= indenter.format(func.getAddListenerBody());
-				buff ~= "\n";
 				buff ~= indenter.format(func.getSignalCallback());
-				buff ~= "\n";
 				buff ~= indenter.format(func.getSignalDestroyCallback());
 				buff ~= "\n";
+				/*
 				buff ~= indenter.format(func.getRemoveListenerDeclaration());
 				buff ~= indenter.format(func.getRemoveListenerBody());
 				buff ~= "\n";
+				*/
 				buff ~= indenter.format(func.getInternalRemoveListenerDeclaration());
 				buff ~= indenter.format(func.getInternalRemoveListenerBody());
-				buff ~= "\n";
 
 				foreach ( param; func.params )
 				{
@@ -533,9 +532,10 @@ final class GtkStruct
 				{
 					buff ~= indenter.format(func.getAddListenerDeclaration() ~ ";");
 					buff ~= "\n";
-
+					/*
 					buff ~= indenter.format(func.getRemoveListenerDeclaration() ~ ";");
 					buff ~= "\n";
+					*/
 				}
 				else
 				{
@@ -889,8 +889,10 @@ final class GtkStruct
 		buff ~= signal.getAddListenerBody();
 		buff ~= signal.getSignalCallback();
 		buff ~= signal.getSignalDestroyCallback();
+		/*
 		buff ~= signal.getRemoveListenerDeclaration();
 		buff ~= signal.getRemoveListenerBody();
+		*/
 		buff ~= signal.getInternalRemoveListenerDeclaration();
 		buff ~= signal.getInternalRemoveListenerBody();
 		

--- a/wrap/utils/GtkStruct.d
+++ b/wrap/utils/GtkStruct.d
@@ -473,7 +473,8 @@ final class GtkStruct
 				*/
 
 				buff ~= indenter.format(func.getDelegateWrapperDeclaration());
-				buff ~= indenter.format(func.getDelegateWrapperName() ~ "[] on" ~ func.getSignalName() ~"Listeners;");
+				buff ~= indenter.format("protected " ~ func.getDelegateWrapperName() ~ "[] on" ~ func.getSignalName() ~"Listeners;");
+				buff ~= "\n";
 
 				buff ~= indenter.format(func.getAddListenerDeclaration());
 				buff ~= indenter.format(func.getAddListenerBody());
@@ -901,7 +902,8 @@ final class GtkStruct
 		signal.name = signal.name ~ "-generic-event";
 
 		buff ~= signal.getDelegateWrapperDeclaration();
-		buff ~= signal.getDelegateWrapperName() ~ "[] on" ~ signal.getSignalName() ~"Listeners;";
+		buff ~= "protected " ~ signal.getDelegateWrapperName() ~ "[] on" ~ signal.getSignalName() ~"Listeners;";
+		buff ~= "\n";
 		
 		//buff ~= func.getDelegateDecleration() ~"[] on"~ signal.getSignalName() ~"Listeners;";
 

--- a/wrap/utils/GtkStruct.d
+++ b/wrap/utils/GtkStruct.d
@@ -454,6 +454,7 @@ final class GtkStruct
 				}
 				*/
 
+				/*
 				if ( isInterface() )
 				{
 					string[] prop;
@@ -476,14 +477,25 @@ final class GtkStruct
 					buff ~= indenter.format("public " ~ func.getDelegateWrapperName() ~ "[] on" ~ func.getSignalName() ~"Listeners;");
 					//buff ~= indenter.format(func.getDelegateDecleration() ~"[] on"~ func.getSignalName() ~"Listeners;");
 				}
+				*/
+
+				buff ~= indenter.format(func.getDelegateWrapperDeclaration());
+				buff ~= indenter.format("protected " ~ func.getDelegateWrapperName() ~ "[] on" ~ func.getSignalName() ~"Listeners;");
 
 				buff ~= "\n";
 				buff ~= indenter.format(func.getAddListenerDeclaration());
 				buff ~= indenter.format(func.getAddListenerBody());
+				buff ~= "\n";
 				buff ~= indenter.format(func.getSignalCallback());
+				buff ~= "\n";
 				buff ~= indenter.format(func.getSignalDestroyCallback());
+				buff ~= "\n";
 				buff ~= indenter.format(func.getRemoveListenerDeclaration());
 				buff ~= indenter.format(func.getRemoveListenerBody());
+				buff ~= "\n";
+				buff ~= indenter.format(func.getInternalRemoveListenerDeclaration());
+				buff ~= indenter.format(func.getInternalRemoveListenerBody());
+				buff ~= "\n";
 
 				foreach ( param; func.params )
 				{
@@ -552,13 +564,14 @@ final class GtkStruct
 
 				if ( func.type == GtkFunctionType.Signal )
 				{
+					/*
 					buff ~= func.getDelegateWrapperDeclaration();
 					buff ~= "\n";
 					buff ~= "public @property "~ func.getDelegateWrapperName() ~"[] on"~ func.getSignalName() ~"Listeners();";
 					buff ~= "\n";
 					buff ~= "public @property void on"~ func.getSignalName() ~"Listeners(" ~ func.getDelegateWrapperName() ~ "[] value);";
 					buff ~= "\n";
-					
+					*/
 					//string[] dec = func.getAddListenerDeclaration();
 					//dec[$-1] ~= ";";
 
@@ -566,6 +579,9 @@ final class GtkStruct
 					buff ~= "\n";
 
 					buff ~= indenter.format(func.getRemoveListenerDeclaration() ~ ";");
+					buff ~= "\n";
+
+					buff ~= indenter.format(func.getInternalRemoveListenerDeclaration() ~ ";");
 					buff ~= "\n";
 				}
 				else
@@ -924,6 +940,8 @@ final class GtkStruct
 		buff ~= signal.getSignalDestroyCallback();
 		buff ~= signal.getRemoveListenerDeclaration();
 		buff ~= signal.getRemoveListenerBody();
+		buff ~= signal.getInternalRemoveListenerDeclaration();
+		buff ~= signal.getInternalRemoveListenerBody();
 		
 		return buff;
 	}

--- a/wrap/utils/GtkStruct.d
+++ b/wrap/utils/GtkStruct.d
@@ -445,39 +445,6 @@ final class GtkStruct
 			if ( func.type == GtkFunctionType.Signal )
 			{
 				buff ~= "\n";
-				/*
-				if ( firstSignal )
-				{
-					buff ~= indenter.format("int[string] connectedSignals;");
-					buff ~= "\n";
-					firstSignal = false;
-				}
-				*/
-
-				/*
-				if ( isInterface() )
-				{
-					string[] prop;
-
-					prop ~= "public " ~ func.getDelegateWrapperName() ~ "[] _on" ~ func.getSignalName() ~"Listeners;";
-					prop ~= "public @property "~ func.getDelegateWrapperName() ~"[] on"~ func.getSignalName() ~"Listeners()";
-					prop ~= "{";
-					prop ~= "return _on"~ func.getSignalName() ~"Listeners;";
-					prop ~= "}";
-					prop ~= "public @property void on"~ func.getSignalName() ~"Listeners(" ~ func.getDelegateWrapperName() ~ "[] value)";
-					prop ~= "{";
-					prop ~= "_on"~ func.getSignalName() ~"Listeners = value;";
-					prop ~= "}";
-					buff ~= indenter.format(prop);
-
-				}
-				else
-				{
-					buff ~= indenter.format(func.getDelegateWrapperDeclaration());
-					buff ~= indenter.format("public " ~ func.getDelegateWrapperName() ~ "[] on" ~ func.getSignalName() ~"Listeners;");
-					//buff ~= indenter.format(func.getDelegateDecleration() ~"[] on"~ func.getSignalName() ~"Listeners;");
-				}
-				*/
 
 				buff ~= indenter.format(func.getDelegateWrapperDeclaration());
 				buff ~= indenter.format("protected " ~ func.getDelegateWrapperName() ~ "[] on" ~ func.getSignalName() ~"Listeners;");
@@ -564,24 +531,10 @@ final class GtkStruct
 
 				if ( func.type == GtkFunctionType.Signal )
 				{
-					/*
-					buff ~= func.getDelegateWrapperDeclaration();
-					buff ~= "\n";
-					buff ~= "public @property "~ func.getDelegateWrapperName() ~"[] on"~ func.getSignalName() ~"Listeners();";
-					buff ~= "\n";
-					buff ~= "public @property void on"~ func.getSignalName() ~"Listeners(" ~ func.getDelegateWrapperName() ~ "[] value);";
-					buff ~= "\n";
-					*/
-					//string[] dec = func.getAddListenerDeclaration();
-					//dec[$-1] ~= ";";
-
 					buff ~= indenter.format(func.getAddListenerDeclaration() ~ ";");
 					buff ~= "\n";
 
 					buff ~= indenter.format(func.getRemoveListenerDeclaration() ~ ";");
-					buff ~= "\n";
-
-					buff ~= indenter.format(func.getInternalRemoveListenerDeclaration() ~ ";");
 					buff ~= "\n";
 				}
 				else
@@ -932,8 +885,6 @@ final class GtkStruct
 		buff ~= "protected " ~ signal.getDelegateWrapperName() ~ "[] on" ~ signal.getSignalName() ~"Listeners;";
 		buff ~= "\n";
 		
-		//buff ~= func.getDelegateDecleration() ~"[] on"~ signal.getSignalName() ~"Listeners;";
-
 		buff ~= declaration;
 		buff ~= signal.getAddListenerBody();
 		buff ~= signal.getSignalCallback();

--- a/wrap/utils/GtkStruct.d
+++ b/wrap/utils/GtkStruct.d
@@ -475,9 +475,11 @@ final class GtkStruct
 				buff ~= indenter.format(func.getDelegateWrapperDeclaration());
 				buff ~= indenter.format(func.getDelegateWrapperName() ~ "[] on" ~ func.getSignalName() ~"Listeners;");
 
-				buff ~= indenter.format(func.getAddListenerdeclaration());
+				buff ~= indenter.format(func.getAddListenerDeclaration());
 				buff ~= indenter.format(func.getAddListenerBody());
 				buff ~= indenter.format(func.getSignalCallback());
+				buff ~= indenter.format(func.getRemoveListenerDeclaration());
+				buff ~= indenter.format(func.getRemoveListenerBody());
 
 				foreach ( param; func.params )
 				{
@@ -547,10 +549,13 @@ final class GtkStruct
 				if ( func.type == GtkFunctionType.Signal )
 				{
 					//buff ~= indenter.format("@property "~ func.getDelegateDecleration() ~"[] on"~ func.getSignalName() ~"Listeners();");
-					string[] dec = func.getAddListenerdeclaration();
-					dec[$-1] ~= ";";
+					//string[] dec = func.getAddListenerDeclaration();
+					//dec[$-1] ~= ";";
 
-					buff ~= indenter.format(dec);
+					buff ~= indenter.format(func.getAddListenerDeclaration() ~ ";");
+					buff ~= "\n";
+
+					buff ~= indenter.format(func.getRemoveListenerDeclaration() ~ ";");
 					buff ~= "\n";
 				}
 				else
@@ -892,7 +897,7 @@ final class GtkStruct
 			}
 		}
 
-		string[] declaration = signal.getAddListenerdeclaration();
+		string[] declaration = signal.getAddListenerDeclaration();
 		signal.name = signal.name ~ "-generic-event";
 
 		buff ~= signal.getDelegateWrapperDeclaration();
@@ -903,6 +908,8 @@ final class GtkStruct
 		buff ~= declaration;
 		buff ~= signal.getAddListenerBody();
 		buff ~= signal.getSignalCallback();
+		buff ~= signal.getRemoveListenerDeclaration();
+		buff ~= signal.getRemoveListenerBody();
 		
 		return buff;
 	}

--- a/wrap/utils/GtkStruct.d
+++ b/wrap/utils/GtkStruct.d
@@ -453,32 +453,35 @@ final class GtkStruct
 					firstSignal = false;
 				}
 				*/
-				/*
+
 				if ( isInterface() )
 				{
 					string[] prop;
 
-					prop ~= func.getDelegateDecleration() ~"[] on"~ func.getSignalName() ~"Listeners;";
-					prop ~= "@property "~ func.getDelegateDecleration() ~"[] on"~ func.getSignalName() ~"Listeners()";
+					prop ~= "public " ~ func.getDelegateWrapperName() ~ "[] _on" ~ func.getSignalName() ~"Listeners;";
+					prop ~= "public @property "~ func.getDelegateWrapperName() ~"[] on"~ func.getSignalName() ~"Listeners()";
 					prop ~= "{";
 					prop ~= "return _on"~ func.getSignalName() ~"Listeners;";
+					prop ~= "}";
+					prop ~= "public @property void on"~ func.getSignalName() ~"Listeners(" ~ func.getDelegateWrapperName() ~ "[] value)";
+					prop ~= "{";
+					prop ~= "_on"~ func.getSignalName() ~"Listeners = value;";
 					prop ~= "}";
 					buff ~= indenter.format(prop);
 
 				}
 				else
 				{
+					buff ~= indenter.format(func.getDelegateWrapperDeclaration());
+					buff ~= indenter.format("public " ~ func.getDelegateWrapperName() ~ "[] on" ~ func.getSignalName() ~"Listeners;");
 					//buff ~= indenter.format(func.getDelegateDecleration() ~"[] on"~ func.getSignalName() ~"Listeners;");
 				}
-				*/
 
-				buff ~= indenter.format(func.getDelegateWrapperDeclaration());
-				buff ~= indenter.format("protected " ~ func.getDelegateWrapperName() ~ "[] on" ~ func.getSignalName() ~"Listeners;");
 				buff ~= "\n";
-
 				buff ~= indenter.format(func.getAddListenerDeclaration());
 				buff ~= indenter.format(func.getAddListenerBody());
 				buff ~= indenter.format(func.getSignalCallback());
+				buff ~= indenter.format(func.getSignalDestroyCallback());
 				buff ~= indenter.format(func.getRemoveListenerDeclaration());
 				buff ~= indenter.format(func.getRemoveListenerBody());
 
@@ -549,7 +552,13 @@ final class GtkStruct
 
 				if ( func.type == GtkFunctionType.Signal )
 				{
-					//buff ~= indenter.format("@property "~ func.getDelegateDecleration() ~"[] on"~ func.getSignalName() ~"Listeners();");
+					buff ~= func.getDelegateWrapperDeclaration();
+					buff ~= "\n";
+					buff ~= "public @property "~ func.getDelegateWrapperName() ~"[] on"~ func.getSignalName() ~"Listeners();";
+					buff ~= "\n";
+					buff ~= "public @property void on"~ func.getSignalName() ~"Listeners(" ~ func.getDelegateWrapperName() ~ "[] value);";
+					buff ~= "\n";
+					
 					//string[] dec = func.getAddListenerDeclaration();
 					//dec[$-1] ~= ";";
 
@@ -792,8 +801,10 @@ final class GtkStruct
 
 			if ( func.type == GtkFunctionType.Signal )
 			{
+				imports ~= "std.algorithm";
 				imports ~= "gobject.Signals";
 				imports ~= "gtkc.gdktypes";
+
 			}
 
 			if ( func.type == GtkFunctionType.Constructor )
@@ -910,6 +921,7 @@ final class GtkStruct
 		buff ~= declaration;
 		buff ~= signal.getAddListenerBody();
 		buff ~= signal.getSignalCallback();
+		buff ~= signal.getSignalDestroyCallback();
 		buff ~= signal.getRemoveListenerDeclaration();
 		buff ~= signal.getRemoveListenerBody();
 		

--- a/wrap/utils/GtkStruct.d
+++ b/wrap/utils/GtkStruct.d
@@ -445,30 +445,35 @@ final class GtkStruct
 			if ( func.type == GtkFunctionType.Signal )
 			{
 				buff ~= "\n";
-
+				/*
 				if ( firstSignal )
 				{
 					buff ~= indenter.format("int[string] connectedSignals;");
 					buff ~= "\n";
 					firstSignal = false;
 				}
-
+				*/
+				/*
 				if ( isInterface() )
 				{
 					string[] prop;
 
-					prop ~= func.getDelegateDecleration() ~"[] _on"~ func.getSignalName() ~"Listeners;";
+					prop ~= func.getDelegateDecleration() ~"[] on"~ func.getSignalName() ~"Listeners;";
 					prop ~= "@property "~ func.getDelegateDecleration() ~"[] on"~ func.getSignalName() ~"Listeners()";
 					prop ~= "{";
 					prop ~= "return _on"~ func.getSignalName() ~"Listeners;";
 					prop ~= "}";
-
 					buff ~= indenter.format(prop);
+
 				}
 				else
 				{
-					buff ~= indenter.format(func.getDelegateDecleration() ~"[] on"~ func.getSignalName() ~"Listeners;");
+					//buff ~= indenter.format(func.getDelegateDecleration() ~"[] on"~ func.getSignalName() ~"Listeners;");
 				}
+				*/
+
+				buff ~= indenter.format(func.getDelegateWrapperDeclaration());
+				buff ~= indenter.format(func.getDelegateWrapperName() ~ "[] on" ~ func.getSignalName() ~"Listeners;");
 
 				buff ~= indenter.format(func.getAddListenerdeclaration());
 				buff ~= indenter.format(func.getAddListenerBody());
@@ -541,7 +546,7 @@ final class GtkStruct
 
 				if ( func.type == GtkFunctionType.Signal )
 				{
-					buff ~= indenter.format("@property "~ func.getDelegateDecleration() ~"[] on"~ func.getSignalName() ~"Listeners();");
+					//buff ~= indenter.format("@property "~ func.getDelegateDecleration() ~"[] on"~ func.getSignalName() ~"Listeners();");
 					string[] dec = func.getAddListenerdeclaration();
 					dec[$-1] ~= ";";
 
@@ -889,8 +894,12 @@ final class GtkStruct
 
 		string[] declaration = signal.getAddListenerdeclaration();
 		signal.name = signal.name ~ "-generic-event";
+
+		buff ~= signal.getDelegateWrapperDeclaration();
+		buff ~= signal.getDelegateWrapperName() ~ "[] on" ~ signal.getSignalName() ~"Listeners;";
 		
-		buff ~= func.getDelegateDecleration() ~"[] on"~ signal.getSignalName() ~"Listeners;";
+		//buff ~= func.getDelegateDecleration() ~"[] on"~ signal.getSignalName() ~"Listeners;";
+
 		buff ~= declaration;
 		buff ~= signal.getAddListenerBody();
 		buff ~= signal.getSignalCallback();


### PR DESCRIPTION
This PR addresses #167 by switching the GtkD event handling mechanism to map every delegate to a unique GTK handler on a 1:1 basis. There are a few benefits to this change as follows:

* Delegates can be removed via Signals.handlerDisconnect
* Delegates can be registered against the same signal using different ConnectFlags. Previously, GtkD only registered a signal handler once so you were limited to using a single ConnectFlag per signal

In general this PR is API compatible with the existing GtkD API with the following exceptions:

* The various public onXXXListeners array fields are no longer exposed publically, any code relying on it to remove delegates will need to switch to using Signals.jandlerDisconnect
* The public associatve array connectedSignals has been removed since it is no longer needed.

I have tested these changes with terminix which is a fairly large GTK program. Obviously however there are many areas of GTK it does not use and my testing with terminix is limited. I would recommend care introducing this change with a relatively long gestation period before using it in a public release.

Note I could not test this with building APILookupGLt.txt and APILookupGLd.txt as I don't have those gir files. 

Feedback welcome, if you require any changes prior to accepting this PR just let me know.