### PR TITLE
use platform independent type in build.d

### DIFF
--- a/Build.d
+++ b/Build.d
@@ -82,7 +82,7 @@ void build(string dir, string lib)
 		{
 			string files = dFiles(dir);
 			
-			int pivot = indexOf(files, ' ', files.length / 2);
+			ptrdiff_t pivot = indexOf(files, ' ', files.length / 2);
 
 			string files2 = files[pivot .. $];
 			files = files [0 .. pivot];


### PR DESCRIPTION
The error that is that the script is only for Windows is only displayed when the script has compiled and runs.