### PR TITLE
fix make all on OSX

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -56,7 +56,7 @@ endif
 
 ifeq ("$(OS)","Darwin")
     SO_POSTFIX=$(SO_VERSION).dylib
-    SONAME=$(LINKERFLAG)-dylib_install_name="$@" $(LINKERFLAG)-dylib_current_version=$(GTKD_VERSION) $(LINKERFLAG)-dylib_compatibility_version=$(MAJOR).0
+    SONAME=$(LINKERFLAG)-dylib_install_name $(LINKERFLAG)"$@" $(LINKERFLAG)-dylib_current_version $(LINKERFLAG)$(GTKD_VERSION) $(LINKERFLAG)-dylib_compatibility_version $(LINKERFLAG)$(MAJOR).0
 else
     SO_POSTFIX=so
     SONAME=$(LINKERFLAG)-soname=$@.$(SO_VERSION)


### PR DESCRIPTION
/cc @MikeWey 
avoids:
ld: unknown option: -dylib_install_name=libgtkd-3.0.dylib

and fixes https://github.com/gtkd-developers/GtkD/issues/233

If https://github.com/dlang/dmd/pull/7863 were accepted, this would've been simpler, eg:
`-L,comma_separated_link_flags`