### PR TITLE
Fix Windows build script for -m64

### DIFF
--- a/Build.d
+++ b/Build.d
@@ -125,7 +125,7 @@ void build(string dir, string lib)
 	}
 	else
 	{
-		std.file.write("build.rf", format("-m64 -c -lib %s %s -Igenerated/gtkd -%s%s.lib %s", dcflags, ldflags, OUTPUT ,lib, dFiles(dir)));
+		std.file.write("build.rf", format("-m64 -c -lib %s %s -Igenerated/gtkd %s%s.lib %s", dcflags, ldflags, OUTPUT ,lib, dFiles(dir)));
 		auto pid = spawnProcess([DC, "@build.rf"]);
 
 		if ( wait(pid) != 0 )


### PR DESCRIPTION
As far as I can tell, there's a typo in the build script.

Running `rdmd -m64 Build.d` results in:

```
Error: unrecognized switch '--ofgtkd.lib'
       run 'dmd -man' to open browser on manual
```

Removing the extraneous dash in the build script fixed the problem and I was able to complete installation and run the example as directed.
