### PR TITLE
Fix candydoc inline code formatting

### DIFF
--- a/docs/candydoc/candy.ddoc
+++ b/docs/candydoc/candy.ddoc
@@ -83,7 +83,7 @@ WHITE = <font color=white>$0</font>
 
 D_CODE = <pre class=\"d_code\">$0</pre>
 DDOC_BACKQUOTED = $(D_INLINECODE $0)
-D_INLINECODE = <pre style=\"display:inline;\" class=\"d_inline_code\">$0</pre>
+D_INLINECODE = <pre style="display:inline;" class="d_inline_code">$0</pre>
 D_COMMENT = $(GREEN $0)
 D_STRING  = $(RED $0)
 D_KEYWORD = $(BLUE $0)

--- a/docs/candydoc/style.css
+++ b/docs/candydoc/style.css
@@ -167,3 +167,12 @@ pre.d_code
 	border: dotted 1px #9c9;
 	background-color: #eeffee;
 }
+
+pre.d_inline_code
+{
+        padding: 1px;
+	border: dotted 1px #9c9;
+	background-color: #eeffee;
+}
+
+


### PR DESCRIPTION
Fixes the formatting of inline preformatted text. See [this comparison](https://imgur.com/a/GZYwxFv) for the change. It generally just makes everything a bit more readable. This fixes one of the small annoyances when reading the docs.

I would be interested in making some more significant changes most notably fixing the docs so that references to other functions/enums/types are correct and not using the C versions.

If the GTKd team are happy for someone to try sort out these issues then I would be happy to do so.