### PR TITLE
Actual fix for shared linking

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -125,12 +125,12 @@ PICOBJECTS_PEASD = $(patsubst %.o,%.pic.o,$(OBJECTS_PEASD))
 USE_RUNTIME_LINKER = $(shell grep "Linker" generated/gtkd/atk/c/functions.d)
 
 ifeq ($(USE_RUNTIME_LINKER),)
-    SOFLAGS_GTKD = $(shell ${PKG_CONFIG} --libs gtk+-3.0 librsvg-2.0 | sed 's/-[lL]/$(LINKERFLAG)&/g')
-    SOFLAGS_GTKDGL = $(LINKERFLAG)-L. $(LINKERFLAG)./libgtkd-$(MAJOR).$(SO_POSTFIX) $(shell ${PKG_CONFIG} --libs gtkglext-3.0 | sed 's/-[lL]/$(LINKERFLAG)&/g')
-    SOFLAGS_GTKDSV = $(LINKERFLAG)-L. $(LINKERFLAG)./libgtkd-$(MAJOR).$(SO_POSTFIX) $(shell ${PKG_CONFIG} --libs gtksourceview-3.0 | sed 's/-[lL]/$(LINKERFLAG)&/g')
-    SOFLAGS_GSTREAMERD = $(LINKERFLAG)-L. $(LINKERFLAG)./libgtkd-$(MAJOR).$(SO_POSTFIX) $(shell ${PKG_CONFIG} --libs gstreamer-base-1.0 | sed 's/-[lL]/$(LINKERFLAG)&/g')
-    SOFLAGS_VTED = $(LINKERFLAG)-L. $(LINKERFLAG)./libgtkd-$(MAJOR).$(SO_POSTFIX) $(shell ${PKG_CONFIG} --libs vte-2.91 | sed 's/-[lL]/$(LINKERFLAG)&/g')
-    SOFLAGS_PEASD = $(LINKERFLAG)-L. $(LINKERFLAG)./libgtkd-$(MAJOR).$(SO_POSTFIX) $(shell ${PKG_CONFIG} --libs-only-l libpeas-1.0 | sed 's/-[lL]/$(LINKERFLAG)&/g')
+    SOFLAGS_GTKD = $(shell ${PKG_CONFIG} --libs-only-l --libs-only-L gtk+-3.0 librsvg-2.0 gmodule-2.0 | sed 's/-[lL]/$(LINKERFLAG)&/g')
+    SOFLAGS_GTKDGL = $(LINKERFLAG)-L. $(LINKERFLAG)./libgtkd-$(MAJOR).$(SO_POSTFIX) $(shell ${PKG_CONFIG} --libs-only-l --libs-only-L gtkglext-3.0 | sed 's/-[lL]/$(LINKERFLAG)&/g')
+    SOFLAGS_GTKDSV = $(LINKERFLAG)-L. $(LINKERFLAG)./libgtkd-$(MAJOR).$(SO_POSTFIX) $(shell ${PKG_CONFIG} --libs-only-l --libs-only-L gtksourceview-3.0 | sed 's/-[lL]/$(LINKERFLAG)&/g')
+    SOFLAGS_GSTREAMERD = $(LINKERFLAG)-L. $(LINKERFLAG)./libgtkd-$(MAJOR).$(SO_POSTFIX) $(shell ${PKG_CONFIG} --libs-only-l --libs-only-L gstreamer-base-1.0 | sed 's/-[lL]/$(LINKERFLAG)&/g')
+    SOFLAGS_VTED = $(LINKERFLAG)-L. $(LINKERFLAG)./libgtkd-$(MAJOR).$(SO_POSTFIX) $(shell ${PKG_CONFIG} --libs-only-l --libs-only-L vte-2.91 | sed 's/-[lL]/$(LINKERFLAG)&/g')
+    SOFLAGS_PEASD = $(LINKERFLAG)-L. $(LINKERFLAG)./libgtkd-$(MAJOR).$(SO_POSTFIX) $(shell ${PKG_CONFIG} --libs-only-l --libs-only-L libpeas-1.0 | sed -e 's/-[lL]/$(LINKERFLAG)&/g')
 endif
 
 #######################################################################

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -290,47 +290,42 @@ gtkd-$(MAJOR).pc:
 	echo Version: $(GTKD_VERSION) >> $@
 	echo Libs: $(LINKERFLAG)-L$(prefix)/$(libdir)/ $(LINKERFLAG)-lgtkd-$(MAJOR) $(LINKERFLAG)-ldl >> $@
 	echo Cflags: -I$(prefix)/include/d/gtkd-$(MAJOR)/ >> $@
-	echo Requires.private: gtk+-3.0, gdk-3.0, atk, pango, cairo, cairo-gobject, pangocairo, librsvg-2.0, gio-2.0, glib-2.0, gobject-2.0, gmodule-2.0 >> $@
+	echo Requires: gtk+-3.0, gdk-3.0, atk, pango, cairo, cairo-gobject, pangocairo, librsvg-2.0, gio-2.0, glib-2.0, gobject-2.0 >> $@
 
 gtkdgl-$(MAJOR).pc:
 	echo Name: GtkDGL > $@
 	echo Description: OpenGL capabilities for GtkD. >> $@
 	echo Version: $(GTKD_VERSION) >> $@
 	echo Libs: $(LINKERFLAG)-lgtkdgl-$(MAJOR) >> $@
-	echo Requires: gtkd-$(MAJOR) >> $@
-	echo Requires.private: gtkglext-1.0 >> $@
+	echo Requires: gtkd-$(MAJOR), gtkglext-1.0 >> $@
 
 gtkdsv-$(MAJOR).pc:
 	echo Name: GtkD SourceView > $@
 	echo Description: A D binding and OO wrapper for GtkSourceView. >> $@
 	echo Version: $(GTKD_VERSION) >> $@
 	echo Libs: $(LINKERFLAG)-lgtkdsv-$(MAJOR) >> $@
-	echo Requires: gtkd-$(MAJOR) >> $@
-	echo Requires.private: gtksourceview-3.0 >> $@
+	echo Requires: gtkd-$(MAJOR), gtksourceview-3.0 >> $@
 
 gstreamerd-$(MAJOR).pc:
 	echo Name: GstreamerD > $@
 	echo Description: A D binding and OO wrapper for Gstreamer. >> $@
 	echo Version: $(GTKD_VERSION) >> $@
 	echo Libs: $(LINKERFLAG)-lgstreamerd-$(MAJOR) >> $@
-	echo Requires: gtkd-$(MAJOR) >> $@
-	echo Requires.private: gstreamer-1.0, gstreamer-base-1.0 >> $@
+	echo Requires: gtkd-$(MAJOR), gstreamer-1.0, gstreamer-base-1.0 >> $@
 
 vted-$(MAJOR).pc:
 	echo Name: VteD > $@
 	echo Description: A D binding and OO wrapper for Vte. >> $@
 	echo Version: $(GTKD_VERSION) >> $@
 	echo Libs: $(LINKERFLAG)-lvted-$(MAJOR) >> $@
-	echo Requires: gtkd-$(MAJOR) >> $@
-	echo Requires.private: vte-2.91 >> $@
+	echo Requires: gtkd-$(MAJOR), vte-2.91 >> $@
 
 peasd-$(MAJOR).pc:
 	echo Name: PeasD > $@
 	echo Description: A D binding and OO wrapper for Peas. >> $@
 	echo Version: $(GTKD_VERSION) >> $@
 	echo Libs: $(LINKERFLAG)-lpeasd-$(MAJOR) >> $@
-	echo Requires: gtkd-$(MAJOR) >> $@
-	echo Requires.private: libpeas-1.0, libpeas-gtk-1.0 >> $@
+	echo Requires: gtkd-$(MAJOR), libpeas-1.0, libpeas-gtk-1.0 >> $@
 
 #######################################################################
 


### PR DESCRIPTION
Sorry for the PR spam :) but the `.private` was a mistake, it only provides include directories, we need libraries.

I posted a description of the problem the `Requires` is solving / working around: https://github.com/ldc-developers/ldc/issues/3111

plus, there was a missing dependency on gmodule

```
ld: error: /usr/local/lib/libgtkd-3.so: undefined reference to g_module_build_path
…
```