### PR TITLE
Deprecate gtk.Arrow

### DIFF
--- a/generated/gtkd/gtk/Arrow.d
+++ b/generated/gtkd/gtk/Arrow.d
@@ -22,6 +22,7 @@
 // implement new conversion functionalities on the wrap.utils pakage
 
 
+deprecated("Use gtk.Image")
 module gtk.Arrow;
 
 private import glib.ConstructionException;


### PR DESCRIPTION
GktArrow has been deprecated since version 3.14.
I couldn't find in APILookupGtk.txt, so edited /generated directly.