### PR TITLE
Fix building demos with dmd v2.096.0

### DIFF
--- a/demos/gtkD/TestWindow/TestAspectFrame.d
+++ b/demos/gtkD/TestWindow/TestAspectFrame.d
@@ -20,7 +20,7 @@ module TestAspectFrame;
 
 private import gtk.AspectFrame;
 
-private import TestDrawingArea;
+private import TestDrawingArea : TestDrawingArea;
 
 /**
  * This tests the DUI aspect frame

--- a/demos/gtkD/TestWindow/TestWindow.d
+++ b/demos/gtkD/TestWindow/TestWindow.d
@@ -40,18 +40,18 @@ import gtk.ApplicationWindow;
 import gtk.Adjustment;
 import gtk.AccelGroup;
 
-import TestEntries;
+import TestEntries : TestEntries;
 
-import TestStock;
-import TestDrawingArea;
-import TestScales;
-import TestText;
-import TestTreeView;
-import TestImage;
-import TestThemes;
-import TestAspectFrame;
-import TestIdle;
-import TTextView;
+import TestStock : TestStock;
+import TestDrawingArea : TestDrawingArea;
+import TestScales : TestScales;
+import TestText : TestText;
+import TestTreeView : TestTreeView;
+import TestImage : TestImage;
+import TestThemes : TestThemes;
+import TestAspectFrame : TestAspectFrame;
+import TestIdle : TestIdle;
+import TTextView : TTextView;
 
 import gtk.MenuItem;
 import gtk.Widget;


### PR DESCRIPTION
Fixes the `import '...' is used as a type` error, that in the demos,
by replacing the problematic imports with selective imports.