### PR TITLE
Add GtkD version to the dub.json

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,5 +1,6 @@
 {
     "name": "gtk-d",
+    "version": "3.9.0",
     "targetType": "none",
     "description": "GtkD is the Digital Mars D programing language OO wrapper for Gtk+.",
     "homepage": "https://gtkd.org",


### PR DESCRIPTION
It is useful for simple changing between gtk3 and gtk4
Like this:
"dependencies": {"gtk-d": "4.0.0"} for gtk4
"dependencies": {"gtk-d": "3.9.0"} for gtk3