### PR TITLE
Patch 4

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -1,5 +1,6 @@
 {
     "name": "gtk-d",
+    "version": "4.0.0",
     "targetType": "none",
     "description": "GtkD is the Digital Mars D programing language OO wrapper for Gtk+.",
     "homepage": "https://gtkd.org",

--- a/generated/gstreamer/gstreamer/DateTime.d
+++ b/generated/gstreamer/gstreamer/DateTime.d
@@ -267,31 +267,6 @@ public class DateTime
 	}
 
 	/**
-	 * Creates a new #GstDateTime using the time since Jan 1, 1970 specified by
-	 * @usecs. The #GstDateTime is in UTC.
-	 *
-	 * Params:
-	 *     usecs = microseconds from the Unix epoch
-	 *
-	 * Returns: a newly created #GstDateTime
-	 *
-	 * Since: 1.18
-	 *
-	 * Throws: ConstructionException GTK+ fails to create the object.
-	 */
-	public this(long usecs)
-	{
-		auto __p = gst_date_time_new_from_unix_epoch_utc_usecs(usecs);
-
-		if(__p is null)
-		{
-			throw new ConstructionException("null returned by new_from_unix_epoch_utc_usecs");
-		}
-
-		this(cast(GstDateTime*) __p);
-	}
-
-	/**
 	 * Creates a new #GstDateTime using the date and times in the gregorian calendar
 	 * in the local timezone.
 	 *

--- a/src/APILookupGStreamer.txt
+++ b/src/APILookupGStreamer.txt
@@ -255,35 +255,6 @@ code: start
 		}
 		this(p); //, true);
 	}
-
-	/**
-	 * Creates a new GstDateTime using the time since Jan 1, 1970 specified by
-	 * secs.
-	 * 
-	 * Params:
-	 *     secs = Seconds from the Unix epoch
-	 *     utc  = If true use utc else use the local timezone.
-	 * Throws: ConstructionException GTK+ fails to create the object.
-	 */
-	public this (long secs, bool utc)
-	{
-		GstDateTime* p;
-
-		if ( utc )
-		{
-			p = gst_date_time_new_from_unix_epoch_utc(secs);
-		}
-		else
-		{
-			p = gst_date_time_new_from_unix_epoch_local_time(secs);
-		}
-
-		if(p is null)
-		{
-			throw new ConstructionException("null returned by gst_date_time_new_from_unix_epoch_local_time(secs)");
-		}
-		this(p); //, true);
-	}
 code: end
 
 struct: DebugMessage


### PR DESCRIPTION
It is useful for simple changing between gtk3 and gtk4
Like this:
"dependencies": {"gtk-d": "4.0.0"} for gtk4
"dependencies": {"gtk-d": "3.9.0"} for gtk3