### PR TITLE
Move method call after nullptr check, avoid segfault

### DIFF
--- a/demos/builder/builderTest.d
+++ b/demos/builder/builderTest.d
@@ -34,8 +34,8 @@ int main(string[] args) {
 			exit(1);
 		}
 		auto window = cast(ApplicationWindow)builder.getObject("window");
-		window.setApplication(application);
 		if (window !is null) {
+			window.setApplication(application);
 			window.setTitle("This is a glade application window");
 			auto button = cast(Button)builder.getObject("button");
 			if(button !is null) {


### PR DESCRIPTION
Obviously we should check for a nullptr returned for window
object from builder.getObject(), before we call methods on it.

Signed-off-by: Carsten Schlote <schlote@vahanus.net>