### PR TITLE
Fix illegal use of "debug(1)"

### DIFF
--- a/demos/gstreamer/mediaplayer/gst_mediaplayer.d
+++ b/demos/gstreamer/mediaplayer/gst_mediaplayer.d
@@ -270,10 +270,10 @@ public:
 		{
 			isPlaying = true;
 			// Now set to playing and iterate.
-			debug(1) writeln("Setting to PLAYING.");
+			debug(trace) writeln("Setting to PLAYING.");
 			//pipeline.setState( GstState.PLAYING );
 			source.setState( GstState.PLAYING );
-			debug(1) writeln("Running.");
+			debug(trace) writeln("Running.");
 		}
 		else
 		{

--- a/demos/gtkD/TestWindow/TestIdle.d
+++ b/demos/gtkD/TestWindow/TestIdle.d
@@ -56,7 +56,7 @@ class TestIdle : VBox
 	this()
 	{
 
-		debug(1)
+		debug(trace)
 		{
 			writeln("instantiating TestTimeout");
 		}

--- a/demos/gtkD/TestWindow/TestImage.d
+++ b/demos/gtkD/TestWindow/TestImage.d
@@ -51,7 +51,7 @@ class TestImage : VBox
 	this(Window window)
 	{
 		this.window = window;
-		debug(1)
+		debug(trace)
 		{
 			writeln("instantiating TestImage");
 		}

--- a/demos/gtkD/TestWindow/TestScales.d
+++ b/demos/gtkD/TestWindow/TestScales.d
@@ -53,7 +53,7 @@ class TestScales : Table //, MenuItemListener
 	this()
 	{
 
-		debug(1)
+		debug(trace)
 		{
 			writeln("instantiating TestScales");
 		}

--- a/demos/gtkD/TestWindow/TestStock.d
+++ b/demos/gtkD/TestWindow/TestStock.d
@@ -43,7 +43,7 @@ class TestStock : ScrolledWindow
 	this()
 	{
 		super(null, null);
-		debug(1)
+		debug(trace)
 		{
 			writeln("instantiating TestStock");
 		}

--- a/demos/gtkD/TestWindow/TestText.d
+++ b/demos/gtkD/TestWindow/TestText.d
@@ -40,7 +40,7 @@ class TestText : VBox
 
 		super(false,0);
 
-		debug(1)
+		debug(trace)
 		{
 			writeln("instantiating TestText");
 		}

--- a/demos/gtkD/TestWindow/TestThemes.d
+++ b/demos/gtkD/TestWindow/TestThemes.d
@@ -39,7 +39,7 @@ class TestThemes : VBox
 	this(Window window)
 	{
 		this.window = window;
-		debug(1)
+		debug(trace)
 		{
 			writeln("instantiating TestThemes");
 		}


### PR DESCRIPTION
I ran into issues while compiling the demos with a recent ldc (1.41.0 (DMD v2.111.0, LLVM 20.1.6)) because it demanded an identifier inside the parentheses. This PR removes the parentheses entirely to revert to the default behaviour.