### PR TITLE
Makefile fixes

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -37,7 +37,7 @@ all: libs shared-libs test
 
 ifeq ("$(DC)","gdc")
     DCFLAGS?=-O2
-    LINKERFLAG?=
+    LINKERFLAG?=-Wl,
     DDOCFLAGS=-fsyntax-only -c -fdoc -fdoc-file=$@
     DDOCINC=-fdoc-inc=
     output=-o $@

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,6 +3,9 @@ prefix?=/usr/local
 pkgconfigdir?=$(libdir)/pkgconfig
 PKG_CONFIG?=pkg-config
 
+GTKD_VERSION=3.11.0
+SO_VERSION=0
+
 OS=$(shell uname || uname -s)
 ARCH=$(shell uname -m || arch)
 
@@ -77,9 +80,6 @@ endif
 ADRDOX?=adrdox
 
 #######################################################################
-
-GTKD_VERSION=3.10.0
-SO_VERSION=0
 
 MAJOR =  $(word 1,$(subst ., ,$(GTKD_VERSION)))
 MINOR =  $(word 2,$(subst ., ,$(GTKD_VERSION)))


### PR DESCRIPTION
Hi!

This patch series versions GtkD correctly, and also fixes linking errors that happen with GDC when `LINKERFLAG` is not set.
We are using those patches in Debian.

Thank you for considering the changes!